### PR TITLE
fix(ios): rename global to not overlap

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -28,10 +28,10 @@ NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 #if !TARGET_OS_OSX
 // runtime trick to remove WKWebView keyboard default toolbar
 // see: http://stackoverflow.com/questions/19033292/ios-7-uiwebview-keyboard-issue/19042279#19042279
-@interface _SwizzleHelperWK : UIView
+@interface __SwizzleHelperWK : UIView
 @property (nonatomic, copy) WKWebView *webView;
 @end
-@implementation _SwizzleHelperWK
+@implementation __SwizzleHelperWK
 -(id)inputAccessoryView
 {
   if (_webView == nil) {
@@ -790,7 +790,7 @@ RCTAutoInsetsProtocol>
   
   if(subview == nil) return;
   
-  NSString* name = [NSString stringWithFormat:@"%@_SwizzleHelperWK", subview.class.superclass];
+  NSString* name = [NSString stringWithFormat:@"%@__SwizzleHelperWK", subview.class.superclass];
   Class newClass = NSClassFromString(name);
   
   if(newClass == nil)
@@ -798,7 +798,7 @@ RCTAutoInsetsProtocol>
     newClass = objc_allocateClassPair(subview.class, [name cStringUsingEncoding:NSASCIIStringEncoding], 0);
     if(!newClass) return;
     
-    Method method = class_getInstanceMethod([_SwizzleHelperWK class], @selector(inputAccessoryView));
+    Method method = class_getInstanceMethod([__SwizzleHelperWK class], @selector(inputAccessoryView));
     class_addMethod(newClass, @selector(inputAccessoryView), method_getImplementation(method), method_getTypeEncoding(method));
     
     objc_registerClassPair(newClass);


### PR DESCRIPTION
`_SwizzleHelperWK` -> `__SwizzleHelperWK`

Fixes the linker error due to re-use 
```
/Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/exodus.app/exodus
duplicate symbol '_OBJC_IVAR_$__SwizzleHelperWK._webView' in:
    /Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/RNNFTViewer/libRNNFTViewer.a(RNNFTViewerView.o)
    /Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/react-native-webview/libreact-native-webview.a(RNCWebView.o)
duplicate symbol '_OBJC_CLASS_$__SwizzleHelperWK' in:
    /Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/RNNFTViewer/libRNNFTViewer.a(RNNFTViewerView.o)
    /Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/react-native-webview/libreact-native-webview.a(RNCWebView.o)
duplicate symbol '_OBJC_METACLASS_$__SwizzleHelperWK' in:
    /Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/RNNFTViewer/libRNNFTViewer.a(RNNFTViewerView.o)
    /Users/timlanahan/Library/Developer/Xcode/DerivedData/exodus-fnapplbgicmjxsbmzvtrtnsvzqsm/Build/Products/Debug-iphonesimulator/react-native-webview/libreact-native-webview.a(RNCWebView.o)
ld: 3 duplicate symbols for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```