### PR TITLE
chore: unify postMessage on iOS & Android

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -749,17 +749,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
           RNCWebView reactWebView = (RNCWebView) root;
           JSONObject eventInitDict = new JSONObject();
           eventInitDict.put("data", args.getString(0));
-          reactWebView.evaluateJavascriptWithFallback("(function () {" +
-            "var event;" +
-            "var data = " + eventInitDict.toString() + ";" +
-            "try {" +
-            "event = new MessageEvent('message', data);" +
-            "} catch (e) {" +
-            "event = document.createEvent('MessageEvent');" +
-            "event.initMessageEvent('message', true, true, data.data, data.origin, data.lastEventId, data.source);" +
-            "}" +
-            "document.dispatchEvent(event);" +
-            "})();");
+          reactWebView.evaluateJavascriptWithFallback("document.dispatchEvent(new MessageEvent('message', " + eventInitDict.toString() + "));");
         } catch (JSONException e) {
           throw new RuntimeException(e);
         }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -885,7 +885,7 @@ RCTAutoInsetsProtocol>
 {
   NSDictionary *eventInitDict = @{@"data": message};
   NSString *source = [NSString
-                      stringWithFormat:@"window.dispatchEvent(new MessageEvent('message', %@));",
+                      stringWithFormat:@"document.dispatchEvent(new MessageEvent('message', %@));",
                       RCTJSONStringify(eventInitDict, NULL)
   ];
   [self injectJavaScript: source];

--- a/example/examples/Messaging.tsx
+++ b/example/examples/Messaging.tsx
@@ -26,7 +26,7 @@ const HTML = `<!DOCTYPE html>\n
         window.ReactNativeWebView.postMessage('Message from JS');
       }
 
-      window.addEventListener('message',function(event){
+      document.addEventListener('message',function(event){
         console.log("Message received from RN: ",event.data)
       },false);
 


### PR DESCRIPTION
This PR unifies the way `postMessage` works on both platforms.

* uses the `document` element rather than `window`, just to prevent processing any cross-origin requests
* simplify android implementation
* use `document` on iOS rather than `window`

We could also make this use the window and set a fake origin, this might be better in the long term.