### PR TITLE
chore: force secure defaults

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -306,7 +306,7 @@ RCTAutoInsetsProtocol>
 {
   WKWebViewConfiguration *wkWebViewConfig = [WKWebViewConfiguration new];
   WKPreferences *prefs = [[WKPreferences alloc]init];
-  BOOL _prefsUsed = NO;
+  BOOL _prefsUsed = YES;
   if (!_javaScriptEnabled) {
     prefs.javaScriptEnabled = NO;
     _prefsUsed = YES;

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -82,7 +82,6 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   style,
   containerStyle,
   source,
-  nativeConfig,
   onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
   ...otherProps
 }, ref) => {
@@ -169,8 +168,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   }
 
 
-  const NativeWebView
-    = (nativeConfig?.component as (typeof NativeWebViewAndroid | undefined)) || RNCWebView;
+  const NativeWebView = RNCWebView;
 
   const webView = <NativeWebView
     key="webViewKey"
@@ -212,7 +210,6 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     mixedContentMode={mixedContentMode}
     nestedScrollEnabled={nestedScrollEnabled}
     mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
-    {...nativeConfig?.props}
   />
 
   return (

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -30,7 +30,7 @@ import styles from './WebView.styles';
 const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', /* 'injectJavaScript', */ 'requestFocus', 'postMessage', 'clearFormData', 'clearCache', 'clearHistory', 'loadUrl'],
 });
 
 const { resolveAssetSource } = Image;
@@ -40,19 +40,30 @@ const { resolveAssetSource } = Image;
  */
 let uniqueRef = 0;
 
+/**
+ * Harcoded default for security.
+ */
+const allowFileAccessFromFileURLs = false;
+const allowUniversalAccessFromFileURLs = false;
+const injectedJavaScriptForMainFrameOnly = true;
+const injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true;
+const mediaPlaybackRequiresUserAction = true;
+// Android only
+const allowsFullscreenVideo = false;
+const allowFileAccess = false;
+const setSupportMultipleWindows = true;
+const mixedContentMode = 'never'
+
 const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   overScrollMode = 'always',
   javaScriptEnabled = true,
   thirdPartyCookiesEnabled = true,
   scalesPageToFit = true,
-  allowsFullscreenVideo = false,
-  allowFileAccess = false,
   saveFormDataDisabled = false,
   cacheEnabled = true,
   androidHardwareAccelerationDisabled = false,
   androidLayerType = "none",
   originWhitelist = defaultOriginWhitelist,
-  setSupportMultipleWindows = true,
   setBuiltInZoomControls = true,
   setDisplayZoomControls = false,
   nestedScrollEnabled = false,
@@ -114,7 +125,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     },
     stopLoading: () => Commands.stopLoading(webViewRef.current),
     postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
-    injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
+    // injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
     requestFocus: () => Commands.requestFocus(webViewRef.current),
     clearFormData: () => Commands.clearFormData(webViewRef.current),
     clearCache: (includeDiskFiles: boolean) => Commands.clearCache(webViewRef.current, includeDiskFiles),
@@ -176,6 +187,9 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     onMessage={onMessage}
     onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
 
+    injectedJavaScriptForMainFrameOnly={injectedJavaScriptForMainFrameOnly}
+    injectedJavaScriptBeforeContentLoadedForMainFrameOnly={injectedJavaScriptBeforeContentLoadedForMainFrameOnly}
+    
     ref={webViewRef}
     // TODO: find a better way to type this.
     source={resolveAssetSource(source as ImageSourcePropType)}
@@ -186,6 +200,8 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     scalesPageToFit={scalesPageToFit}
     allowsFullscreenVideo={allowsFullscreenVideo}
     allowFileAccess={allowFileAccess}
+    allowFileAccessFromFileURLs={allowFileAccessFromFileURLs}
+    allowUniversalAccessFromFileURLs={allowUniversalAccessFromFileURLs}
     saveFormDataDisabled={saveFormDataDisabled}
     cacheEnabled={cacheEnabled}
     androidHardwareAccelerationDisabled={androidHardwareAccelerationDisabled}
@@ -193,7 +209,9 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     setSupportMultipleWindows={setSupportMultipleWindows}
     setBuiltInZoomControls={setBuiltInZoomControls}
     setDisplayZoomControls={setDisplayZoomControls}
+    mixedContentMode={mixedContentMode}
     nestedScrollEnabled={nestedScrollEnabled}
+    mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
     {...nativeConfig?.props}
   />
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -94,7 +94,6 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   style,
   containerStyle,
   source,
-  nativeConfig,
   incognito,
   decelerationRate: decelerationRateProp,
   onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
@@ -107,12 +106,10 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     _url: string,
     lockIdentifier = 0,
   ) => {
-    const viewManager
-      = (nativeConfig?.viewManager)
-      || RNCWebViewManager;
+    const viewManager = RNCWebViewManager;
 
     viewManager.startLoadWithResult(!!shouldStart, lockIdentifier);
-  }, [nativeConfig?.viewManager]);
+  }, []);
 
   const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onHttpError, onLoadingError, onLoadingFinish, onLoadingProgress, onContentProcessDidTerminate } = useWebWiewLogic({
     onNavigationStateChange,
@@ -170,9 +167,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
 
   const decelerationRate = processDecelerationRate(decelerationRateProp);
 
-  const NativeWebView
-  = (nativeConfig?.component as typeof NativeWebViewIOS | undefined)
-  || RNCWebView;
+  const NativeWebView = RNCWebView;
 
   const webView = (
     <NativeWebView
@@ -210,7 +205,6 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       // TODO: find a better way to type this.
       source={resolveAssetSource(source as ImageSourcePropType)}
       style={webViewStyles}
-      {...nativeConfig?.props}
     />
   );
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -29,7 +29,7 @@ import styles from './WebView.styles';
 const codegenNativeCommands = codegenNativeCommandsUntyped as <T extends {}>(options: { supportedCommands: (keyof T)[] }) => T;
 
 const Commands = codegenNativeCommands({
-  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', 'injectJavaScript', 'requestFocus', 'postMessage', 'loadUrl'],
+  supportedCommands: ['goBack', 'goForward', 'reload', 'stopLoading', /* 'injectJavaScript', */ 'requestFocus', 'postMessage', 'loadUrl'],
 });
 
 const { resolveAssetSource } = Image;
@@ -55,16 +55,30 @@ const useWarnIfChanges = <T extends unknown>(value: T, name: string) => {
   }
 }
 
+/**
+ * Harcoded defaults for security.
+ */
+const allowFileAccessFromFileURLs = false;
+const allowUniversalAccessFromFileURLs = false;
+const injectedJavaScriptForMainFrameOnly = true;
+const injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true;
+const mediaPlaybackRequiresUserAction = true;
+// iOS only configs
+const allowsInlineMediaPlayback = true;
+const allowsAirPlayForMediaPlayback = false;
+const useSharedProcessPool = false;
+const sharedCookiesEnabled = false;
+const enableApplePay = false;
+const onFileDownload = () => console.error('tried to download file')
+const dataDetectorTypes = 'none';
+
 const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   javaScriptEnabled = true,
   cacheEnabled = true,
   originWhitelist = defaultOriginWhitelist,
-  useSharedProcessPool= true,
   textInteractionEnabled= true,
   injectedJavaScript,
   injectedJavaScriptBeforeContentLoaded,
-  injectedJavaScriptForMainFrameOnly = true,
-  injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true,
   startInLoadingState,
   onNavigationStateChange,
   onLoadStart,
@@ -73,7 +87,6 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   onLoadEnd,
   onLoadProgress,
   onContentProcessDidTerminate: onContentProcessDidTerminateProp,
-  onFileDownload,
   onHttpError: onHttpErrorProp,
   onMessage: onMessageProp,
   renderLoading,
@@ -82,10 +95,6 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   containerStyle,
   source,
   nativeConfig,
-  allowsInlineMediaPlayback,
-  allowsAirPlayForMediaPlayback,
-  mediaPlaybackRequiresUserAction,
-  dataDetectorTypes,
   incognito,
   decelerationRate: decelerationRateProp,
   onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
@@ -131,7 +140,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     },
     stopLoading: () => Commands.stopLoading(webViewRef.current),
     postMessage: (data: string) => Commands.postMessage(webViewRef.current, data),
-    injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
+    // injectJavaScript: (data: string) => Commands.injectJavaScript(webViewRef.current, data),
     requestFocus: () => Commands.requestFocus(webViewRef.current),
   }), [setViewState, webViewRef]);
 
@@ -169,8 +178,12 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     <NativeWebView
       key="webViewKey"
       {...otherProps}
+      allowFileAccessFromFileURLs={allowFileAccessFromFileURLs}
+      allowUniversalAccessFromFileURLs={allowUniversalAccessFromFileURLs}
+      enableApplePay={enableApplePay}
       javaScriptEnabled={javaScriptEnabled}
       cacheEnabled={cacheEnabled}
+      dataDetectorTypes={dataDetectorTypes}
       useSharedProcessPool={useSharedProcessPool}
       textInteractionEnabled={textInteractionEnabled}
       decelerationRate={decelerationRate}
@@ -188,12 +201,12 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
       injectedJavaScriptBeforeContentLoaded={injectedJavaScriptBeforeContentLoaded}
       injectedJavaScriptForMainFrameOnly={injectedJavaScriptForMainFrameOnly}
       injectedJavaScriptBeforeContentLoadedForMainFrameOnly={injectedJavaScriptBeforeContentLoadedForMainFrameOnly}
-      dataDetectorTypes={dataDetectorTypes}
       allowsAirPlayForMediaPlayback={allowsAirPlayForMediaPlayback}
       allowsInlineMediaPlayback={allowsInlineMediaPlayback}
       incognito={incognito}
       mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
       ref={webViewRef}
+      sharedCookiesEnabled={sharedCookiesEnabled}
       // TODO: find a better way to type this.
       source={resolveAssetSource(source as ImageSourcePropType)}
       style={webViewStyles}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -230,25 +230,6 @@ export interface ViewManager {
   startLoadWithResult: Function;
 }
 
-export interface WebViewNativeConfig {
-  /**
-   * The native component used to render the WebView.
-   */
-  component?:
-    | typeof NativeWebViewIOS
-    | typeof NativeWebViewAndroid;
-  /**
-   * Set props directly on the native component WebView. Enables custom props which the
-   * original WebView doesn't pass through.
-   */
-  props?: Object;
-  /**
-   * Set the ViewManager to use for communication with the native side.
-   * @platform ios, macos
-   */
-  viewManager?: ViewManager;
-}
-
 export type OnShouldStartLoadWithRequest = (
   event: ShouldStartLoadRequest,
 ) => boolean;
@@ -1072,12 +1053,6 @@ export interface WebViewSharedProps extends ViewProps {
    * to stop loading. The `navigationType` is always `other` on android.
    */
   onShouldStartLoadWithRequest?: OnShouldStartLoadWithRequest;
-
-  /**
-   * Override the native component used to render the WebView. Enables a custom native
-   * WebView which uses the same JavaScript as the original WebView.
-   */
-  nativeConfig?: WebViewNativeConfig;
 
   /**
    * Should caching be enabled. Default is true.

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -266,6 +266,7 @@ export interface BasicAuthCredential {
 }
 
 export interface CommonNativeWebViewProps extends ViewProps {
+  allowFileAccessFromFileURLs?: boolean;
   cacheEnabled?: boolean;
   incognito?: boolean;
   injectedJavaScript?: string;
@@ -299,7 +300,6 @@ export interface AndroidNativeWebViewProps extends CommonNativeWebViewProps {
   cacheMode?: CacheMode;
   allowFileAccess?: boolean;
   scalesPageToFit?: boolean;
-  allowFileAccessFromFileURLs?: boolean;
   allowsFullscreenVideo?: boolean;
   allowUniversalAccessFromFileURLs?: boolean;
   androidHardwareAccelerationDisabled?: boolean;
@@ -348,7 +348,6 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   allowsInlineMediaPlayback?: boolean;
   allowsAirPlayForMediaPlayback?: boolean;
   allowsLinkPreview?: boolean;
-  allowFileAccessFromFileURLs?: boolean;
   allowUniversalAccessFromFileURLs?: boolean;
   automaticallyAdjustContentInsets?: boolean;
   autoManageStatusBarEnabled?: boolean;
@@ -369,6 +368,8 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   injectedJavaScriptBeforeContentLoadedForMainFrameOnly?: boolean;
   onFileDownload?: (event: FileDownloadEvent) => void;
   limitsNavigationsToAppBoundDomains?: boolean;
+  sharedCookiesEnabled?: boolean;
+  enableApplePay?: boolean;
   textInteractionEnabled?: boolean;
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
 }


### PR DESCRIPTION
This PR hardcodes a bunch of toggles and ensures that the safe defaults are always followed. This means consumers of this package won't be able to set any other values.

All
* Removal of the `injectJavascript` method
* allowFileAccessFromFileURLs = false
* allowUniversalAccessFromFileURLs = false
* injectedJavaScriptForMainFrameOnly = true
* injectedJavaScriptBeforeContentLoadedForMainFrameOnly = true
* mediaPlaybackRequiresUserAction = true

Android only

* allowsFullscreenVideo = false
* allowFileAccess = false
* setSupportMultipleWindows = true
* mixedContentMode = 'never'

iOS only config

* allowsInlineMediaPlayback = true
* allowsAirPlayForMediaPlayback = false
* useSharedProcessPool = false
* sharedCookiesEnabled = false
* enableApplePay = false
* onFileDownload = `() => console.error('tried to download file')`
* dataDetectorTypes = 'none'