### PR TITLE
Set minimum ios versions

### DIFF
--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -64,7 +64,7 @@ const useSharedProcessPool = false;
 const sharedCookiesEnabled = false;
 const enableApplePay = false;
 const dataDetectorTypes = 'none';
-const hardMinimumIOSVersion = '12.5.6' // TODO: determinime a good lower bound
+const hardMinimumIOSVersion = '12.5.6 <13, 13.6.1 <14, 14.8.1 <15, 15.7.1'
 
 const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   javaScriptEnabled = true,


### PR DESCRIPTION
* 12.5.6: https://support.apple.com/en-us/HT213428 -- August 31, 2022
* 13.6: https://support.apple.com/en-us/HT211288
   We use 13.6.1: https://support.apple.com/en-us/HT210393#1361 -- August 12, 2020
* 14.8.1: https://support.apple.com/en-us/HT212868 -- October 26, 2021
* 15.7.1: https://support.apple.com/en-us/HT213490 -- October 27, 2022