### PR TITLE
feat(dapps): add handler for unsupported os version

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -151,7 +151,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   const version = userAgent.match(/chrome\/((?:[0-9]+\.)+[0-9]+)/i)?.[1]
   if (!(versionPasses(version, minimumChromeVersion) && versionPasses(version, hardMinimumChromeVersion))) {
     if (UnsupportedVersionComponent) {
-      return <UnsupportedVersionComponent device="android" />
+      return <UnsupportedVersionComponent />
     }
     return (
       <View style={{ alignSelf: 'flex-start' }}>

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -85,6 +85,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   validateMeta,
   validateData,
   minimumChromeVersion,
+  unsupportedVersionComponent: UnsupportedVersionComponent,
   ...otherProps
 }, ref) => {
   const messagingModuleName = useRef<string>(`WebViewMessageHandler${uniqueRef += 1}`).current;
@@ -149,6 +150,9 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   if (!userAgent) return null // stop the rendering until userAgent is known
   const version = userAgent.match(/chrome\/((?:[0-9]+\.)+[0-9]+)/i)?.[1]
   if (!(versionPasses(version, minimumChromeVersion) && versionPasses(version, hardMinimumChromeVersion))) {
+    if (UnsupportedVersionComponent) {
+      return <UnsupportedVersionComponent device="android" />
+    }
     return (
       <View style={{ alignSelf: 'flex-start' }}>
         <Text style={{ color: 'red' }}>

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -142,7 +142,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   const version = String(Platform.Version)
   if (!(versionPasses(version, minimumIOSVersion) && versionPasses(version, hardMinimumIOSVersion))) {
     if (UnsupportedVersionComponent) {
-      return <UnsupportedVersionComponent device="ios"/>
+      return <UnsupportedVersionComponent />
     }
     return (
       <View style={{ alignSelf: 'flex-start' }}>

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -90,6 +90,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   decelerationRate: decelerationRateProp,
   onShouldStartLoadWithRequest: onShouldStartLoadWithRequestProp,
   minimumIOSVersion,
+  unsupportedVersionComponent: UnsupportedVersionComponent,
   ...otherProps
 }, ref) => {
   const webViewRef = useRef<NativeWebViewIOS | null>(null);
@@ -140,6 +141,9 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
 
   const version = String(Platform.Version)
   if (!(versionPasses(version, minimumIOSVersion) && versionPasses(version, hardMinimumIOSVersion))) {
+    if (UnsupportedVersionComponent) {
+      return <UnsupportedVersionComponent device="ios"/>
+    }
     return (
       <View style={{ alignSelf: 'flex-start' }}>
         <Text style={{ color: 'red' }}>

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -906,4 +906,10 @@ export interface WebViewSharedProps extends ViewProps {
    * Webview will refuse to work on Chrome versions below this one. Required for Android.
    */
   minimumChromeVersion?: string,
+
+  /**
+   * Component to render if the OS version is not supported.
+   */
+
+  unsupportedVersionComponent?: ReactElement,
 }

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -24,10 +24,6 @@ type WebViewCommands =
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
 
-interface UnsupportedVersionProps {
-  device: string;
-}
-
 interface RNCWebViewUIManager<Commands extends string> extends UIManagerStatic {
   getViewManagerConfig: (name: string) => {
     Commands: { [key in Commands]: number };
@@ -910,10 +906,4 @@ export interface WebViewSharedProps extends ViewProps {
    * Webview will refuse to work on Chrome versions below this one. Required for Android.
    */
   minimumChromeVersion?: string,
-
-  /**
-   * Component to render if the OS version is not supported.
-   */
-
-  unsupportedVersionComponent?: React.ComponentType<UnsupportedVersionProps>,
 }

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -24,6 +24,10 @@ type WebViewCommands =
 
 type AndroidWebViewCommands = 'clearHistory' | 'clearCache' | 'clearFormData';
 
+interface UnsupportedVersionProps {
+  device: string;
+}
+
 interface RNCWebViewUIManager<Commands extends string> extends UIManagerStatic {
   getViewManagerConfig: (name: string) => {
     Commands: { [key in Commands]: number };
@@ -906,4 +910,10 @@ export interface WebViewSharedProps extends ViewProps {
    * Webview will refuse to work on Chrome versions below this one. Required for Android.
    */
   minimumChromeVersion?: string,
+
+  /**
+   * Component to render if the OS version is not supported.
+   */
+
+  unsupportedVersionComponent?: React.ComponentType<UnsupportedVersionProps>,
 }


### PR DESCRIPTION
Summary

Adds handler for unsupported os version. 
This should be rendered if provided, else defaults to the hardcoded response