### PR TITLE
fix: use correct type for component prop

### DIFF
--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-multi-comp, max-classes-per-file */
-
-import { ReactElement, Component } from 'react';
+import { ReactElement, Component, ElementType } from 'react';
 import {
   NativeSyntheticEvent,
   ViewProps,
@@ -911,5 +910,5 @@ export interface WebViewSharedProps extends ViewProps {
    * Component to render if the OS version is not supported.
    */
 
-  unsupportedVersionComponent?: ReactElement,
+  unsupportedVersionComponent?: ElementType,
 }


### PR DESCRIPTION
## summary

Regression from [PR](https://github.com/ExodusMovement/react-native-webview/pull/12).
Properly `type` component element prop.