### PR TITLE
feat: add webview debuggging

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -338,6 +338,11 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     CookieManager.getInstance().setAcceptThirdPartyCookies(view, enabled);
   }
 
+  @ReactProp(name = "webviewDebuggingEnabled")
+  public void setWebviewDebuggingEnabled(WebView view, boolean value) {
+      ((RNCWebView) view).setWebContentsDebuggingEnabled(value);
+  }
+
   @ReactProp(name = "textZoom")
   public void setTextZoom(WebView view, int value) {
     view.getSettings().setTextZoom(value);

--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -48,6 +48,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *_Nonnull)request
 @property (nonatomic, assign) BOOL pagingEnabled;
 @property (nonatomic, assign) CGFloat decelerationRate;
 @property (nonatomic, assign) BOOL allowsInlineMediaPlayback;
+@property (nonatomic, assign) BOOL webviewDebuggingEnabled;
 @property (nonatomic, assign) BOOL bounces;
 @property (nonatomic, assign) BOOL mediaPlaybackRequiresUserAction;
 #if WEBKIT_IOS_10_APIS_AVAILABLE

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -406,6 +406,13 @@ RCTAutoInsetsProtocol>
     }
 #endif
     
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130300 || \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400 || \
+    __TV_OS_VERSION_MAX_ALLOWED >= 160400
+    if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *))
+      _webView.inspectable = _webviewDebuggingEnabled;
+#endif
+
     [self addSubview:_webView];
     [self setHideKeyboardAccessoryView: _savedHideKeyboardAccessoryView];
     [self setKeyboardDisplayRequiresUserAction: _savedKeyboardDisplayRequiresUserAction];
@@ -430,6 +437,16 @@ RCTAutoInsetsProtocol>
   _allowsBackForwardNavigationGestures = allowsBackForwardNavigationGestures;
   _webView.allowsBackForwardNavigationGestures = _allowsBackForwardNavigationGestures;
 }
+
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 130300 || \
+    __IPHONE_OS_VERSION_MAX_ALLOWED >= 160400 || \
+    __TV_OS_VERSION_MAX_ALLOWED >= 160400
+- (void)setWebviewDebuggingEnabled:(BOOL)webviewDebuggingEnabled {
+  _webviewDebuggingEnabled = webviewDebuggingEnabled;
+  if (@available(macOS 13.3, iOS 16.4, tvOS 16.4, *))
+      _webView.inspectable = _webviewDebuggingEnabled;
+}
+#endif
 
 - (void)removeFromSuperview
 {

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -63,6 +63,7 @@ RCT_EXPORT_VIEW_PROPERTY(injectedJavaScript, NSString)
 RCT_EXPORT_VIEW_PROPERTY(injectedJavaScriptBeforeContentLoaded, NSString)
 RCT_EXPORT_VIEW_PROPERTY(javaScriptEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsInlineMediaPlayback, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(webviewDebuggingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(mediaPlaybackRequiresUserAction, BOOL)
 #if WEBKIT_IOS_10_APIS_AVAILABLE
 RCT_EXPORT_VIEW_PROPERTY(dataDetectorTypes, WKDataDetectorTypes)

--- a/docs/Reference.md
+++ b/docs/Reference.md
@@ -83,6 +83,7 @@ This document lays out the current public properties and methods for the React N
 - [`downloadingMessage`](Reference.md#downloadingMessage)
 - [`lackPermissionToDownloadMessage`](Reference.md#lackPermissionToDownloadMessage)
 - [`allowsProtectedMedia`](Reference.md#allowsProtectedMedia)
+- [`webviewDebuggingEnabled`](Reference.md#webviewDebuggingEnabled)
 
 ## Methods Index
 
@@ -1527,6 +1528,15 @@ Whether or not the Webview can play media protected by DRM. Default is false.
 | Type   | Required | Platform |
 | ------ | -------- | -------- |
 | boolean | No       | Android  |
+
+### `webviewDebuggingEnabled`
+
+Whether or not the webview can be debugged remotely using Safari / Chrome.
+Default is false. Supported on iOS as of 16.4, previous versions always allow debugging by default.
+
+| Type    | Required | Platform |
+| ------- | -------- | -------- |
+| boolean | No       | iOS & Android  |
 
 ## Methods
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -229,6 +229,7 @@ export interface CommonNativeWebViewProps extends ViewProps {
   injectedJavaScript?: string;
   injectedJavaScriptBeforeContentLoaded?: string;
   mediaPlaybackRequiresUserAction?: boolean;
+  webviewDebuggingEnabled?: boolean;
   messagingEnabled: boolean;
   onScroll?: (event: WebViewScrollEvent) => void;
   onLoadingError: (event: WebViewErrorEvent) => void;
@@ -886,6 +887,11 @@ export interface WebViewSharedProps extends ViewProps {
    */
   basicAuthCredential?: BasicAuthCredential;
 
+  /**
+   * Enables WebView remote debugging using Chrome (Android) or Safari (iOS).
+   */
+  webviewDebuggingEnabled?: boolean;
+  
   /**
    * Event metadata validation.
    */


### PR DESCRIPTION
This PR adds an option to dynamically enable debugging on a WebView. At the moment debuggin on iOS simply isn't possible beyond a certain version. This PR simply ports over f9a527753fed972650de5a0e4a5000b278926b9b.

https://github.com/react-native-webview/react-native-webview/commit/f9a527753fed972650de5a0e4a5000b278926b9b#diff-1e9e186ed31b824037d8583c933e3795b7f72e057c87c8822d0d925d81c109ff