### PR TITLE
feat(android): add `onOpenWindow` event

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/code
   docker:
-    - image: cimg/node:14.17.6-browsers
+    - image: cimg/node:16.13.0-browsers
 
 version: 2
 jobs:

--- a/.github/workflows/detox.yml
+++ b/.github/workflows/detox.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@master
       - uses: actions/setup-node@master
         with:
-          node-version: 14
+          node-version: 16
       - name: Setup - Install Yarn
         run: YARN_GPG=NO curl -o- -L https://yarnpkg.com/install.sh | bash
       - name: Setup - Install NPM Dependencies

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -2,7 +2,7 @@ name: iOS
 on: [push, pull_request]
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -79,6 +79,7 @@ import com.reactnativecommunity.webview.RNCWebViewModule.ShouldOverrideUrlLoadin
 import com.reactnativecommunity.webview.events.TopLoadingErrorEvent;
 import com.reactnativecommunity.webview.events.TopLoadingFinishEvent;
 import com.reactnativecommunity.webview.events.TopLoadingProgressEvent;
+import com.reactnativecommunity.webview.events.TopOpenWindowEvent;
 import com.reactnativecommunity.webview.events.TopLoadingStartEvent;
 import com.reactnativecommunity.webview.events.TopMessageEvent;
 import com.reactnativecommunity.webview.events.TopShouldStartLoadWithRequestEvent;
@@ -595,6 +596,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     export.put(TopLoadingProgressEvent.EVENT_NAME, MapBuilder.of("registrationName", "onLoadingProgress"));
     export.put(TopShouldStartLoadWithRequestEvent.EVENT_NAME, MapBuilder.of("registrationName", "onShouldStartLoadWithRequest"));
     export.put(ScrollEventType.getJSEventName(ScrollEventType.SCROLL), MapBuilder.of("registrationName", "onScroll"));
+    export.put(TopOpenWindowEvent.EVENT_NAME, MapBuilder.of("registrationName", "onOpenWindow"));
     return export;
   }
 
@@ -991,6 +993,20 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
     public boolean onCreateWindow(WebView view, boolean isDialog, boolean isUserGesture, Message resultMsg) {
 
       final WebView newWebView = new WebView(view.getContext());
+      newWebView.setWebViewClient(new WebViewClient(){
+        @Override
+        public boolean shouldOverrideUrlLoading (WebView subview, String url) {
+        WritableMap event = Arguments.createMap();
+        event.putString("targetUrl", url);
+
+        ((RNCWebView) view).dispatchEvent(
+          view,
+          new TopOpenWindowEvent(view.getId(), event)
+        );
+
+        return true;
+        }
+      });
       final WebView.WebViewTransport transport = (WebView.WebViewTransport) resultMsg.obj;
       transport.setWebView(newWebView);
       resultMsg.sendToTarget();

--- a/android/src/main/java/com/reactnativecommunity/webview/events/TopNewWindowEvent.kt
+++ b/android/src/main/java/com/reactnativecommunity/webview/events/TopNewWindowEvent.kt
@@ -1,0 +1,25 @@
+package com.reactnativecommunity.webview.events
+
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.facebook.react.uimanager.events.RCTEventEmitter
+
+/**
+ * Event emitted when the WebView opens a new Window (i.e: target=_blank)
+ */
+class TopOpenWindowEvent(viewId: Int, private val mEventData: WritableMap) :
+  Event<TopOpenWindowEvent>(viewId) {
+  companion object {
+    const val EVENT_NAME = "topOpenWindow"
+  }
+
+  override fun getEventName(): String = EVENT_NAME
+
+  override fun canCoalesce(): Boolean = false
+
+  override fun getCoalescingKey(): Short = 0
+
+  override fun dispatch(rctEventEmitter: RCTEventEmitter) =
+    rctEventEmitter.receiveEvent(viewTag, eventName, mEventData)
+
+}

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -76,6 +76,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   onLoad,
   onLoadEnd,
   onMessage: onMessageProp,
+  onOpenWindow: onOpenWindowProp,
   renderLoading,
   renderError,
   style,
@@ -101,12 +102,13 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     }
   }, []);
 
-  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onLoadingError, onLoadingFinish, onLoadingProgress, passesWhitelist } = useWebWiewLogic({
+  const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onLoadingError, onLoadingFinish, onLoadingProgress, onOpenWindow, passesWhitelist } = useWebWiewLogic({
     onLoad,
     onError,
     onLoadEnd,
     onLoadStart,
     onMessageProp,
+    onOpenWindowProp,
     startInLoadingState,
     originWhitelist,
     onShouldStartLoadWithRequestProp,
@@ -207,6 +209,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     onLoadingProgress={onLoadingProgress}
     onLoadingStart={onLoadingStart}
     onMessage={onMessage}
+    onOpenWindow={onOpenWindow}
     onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
     
     ref={webViewRef}

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -9,6 +9,7 @@ import {
   WebViewMessageEvent,
   WebViewMessage,
   WebViewNavigationEvent,
+  WebViewOpenWindowEvent,
   WebViewProgressEvent,
   WebViewNativeEvent,
 } from './WebViewTypes';
@@ -104,6 +105,7 @@ export const useWebWiewLogic = ({
   onLoadEnd,
   onError,
   onMessageProp,
+  onOpenWindowProp,
   originWhitelist,
   onShouldStartLoadWithRequestProp,
   onShouldStartLoadWithRequestCallback,
@@ -116,6 +118,7 @@ export const useWebWiewLogic = ({
   onLoadEnd?: (event: WebViewNavigationEvent | WebViewErrorEvent) => void;
   onError?: (event: WebViewErrorEvent) => void;
   onMessageProp?: (event: WebViewMessage) => void;
+  onOpenWindowProp?: (event: WebViewOpenWindowEvent) => void;
   originWhitelist: readonly string[];
   onShouldStartLoadWithRequestProp?: OnShouldStartLoadWithRequest;
   onShouldStartLoadWithRequestCallback: (shouldStart: boolean, url: string, lockIdentifier?: number | undefined) => void;
@@ -209,6 +212,12 @@ export const useWebWiewLogic = ({
     )
   , [originWhitelist, onShouldStartLoadWithRequestProp, onShouldStartLoadWithRequestCallback])
 
+  // Android Only
+  const onOpenWindow = useCallback((event: WebViewOpenWindowEvent) => {
+    onOpenWindowProp?.(event);
+  }, [onOpenWindowProp]);
+  // !Android Only
+
   return {
     onShouldStartLoadWithRequest,
     onLoadingStart,
@@ -216,6 +225,7 @@ export const useWebWiewLogic = ({
     onLoadingError,
     onLoadingFinish,
     onMessage,
+    onOpenWindow,
     passesWhitelist,
     viewState,
     setViewState,

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -10,8 +10,6 @@ import {
   UIManagerStatic,
   NativeScrollEvent,
 } from 'react-native';
-// @ts-expect-error react-native doesn't have this type
-import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type WebViewCommands =
   | 'goForward'
@@ -243,7 +241,7 @@ export interface CommonNativeWebViewProps extends ViewProps {
   onLoadingProgress: (event: WebViewProgressEvent) => void;
   onLoadingStart: (event: WebViewNavigationEvent) => void;
   onMessage: (event: WebViewMessageEvent) => void;
-  onOpenWindow?: DirectEventHandler<WebViewOpenWindowEvent>;
+  onOpenWindow?: (event: WebViewOpenWindowEvent) => void;
   onShouldStartLoadWithRequest: (event: ShouldStartLoadRequestEvent) => void;
   showsHorizontalScrollIndicator?: boolean;
   showsVerticalScrollIndicator?: boolean;

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -10,6 +10,7 @@ import {
   UIManagerStatic,
   NativeScrollEvent,
 } from 'react-native';
+import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type WebViewCommands =
   | 'goForward'
@@ -79,6 +80,10 @@ export interface WebViewNativeEvent {
   canGoForward: boolean;
   lockIdentifier: number;
 }
+
+export type WebViewOpenWindowEvent = Readonly<{
+  targetUrl: string;
+}>
 
 export interface WebViewNativeProgressEvent extends WebViewNativeEvent {
   progress: number;
@@ -237,6 +242,7 @@ export interface CommonNativeWebViewProps extends ViewProps {
   onLoadingProgress: (event: WebViewProgressEvent) => void;
   onLoadingStart: (event: WebViewNavigationEvent) => void;
   onMessage: (event: WebViewMessageEvent) => void;
+  onOpenWindow?: DirectEventHandler<WebViewOpenWindowEvent>;
   onShouldStartLoadWithRequest: (event: ShouldStartLoadRequestEvent) => void;
   showsHorizontalScrollIndicator?: boolean;
   showsVerticalScrollIndicator?: boolean;
@@ -571,6 +577,16 @@ export interface IOSWebViewProps extends WebViewSharedProps {
 
 export interface AndroidWebViewProps extends WebViewSharedProps {
   onContentSizeChange?: (event: WebViewEvent) => void;
+
+  /**
+   * Function that is invoked when the `WebView` should open a new window.
+   * 
+   * This happens when the JS calls `window.open('http://someurl', '_blank')`
+   * or when the user clicks on a `<a href="http://someurl" target="_blank">` link.
+   *
+   * @platform android
+   */
+  onOpenWindow?: (event: WebViewOpenWindowEvent) => void;
 
   /**
    * https://developer.android.com/reference/android/webkit/WebSettings.html#setCacheMode(int)

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -10,6 +10,7 @@ import {
   UIManagerStatic,
   NativeScrollEvent,
 } from 'react-native';
+// @ts-expect-error react-native doesn't have this type
 import type { DirectEventHandler } from 'react-native/Libraries/Types/CodegenTypes';
 
 type WebViewCommands =


### PR DESCRIPTION
Implement `onOpenWindow` to intercept iframe openning as alternative of [this PR](https://github.com/ExodusMovement/react-native-webview/pull/17) to open iframes on android.

this implementation ins based on [original lib PR](https://github.com/react-native-webview/react-native-webview/pull/2640) and included only the minimal necessary android code to our usage.