### PR TITLE
fix: allow deep linking

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -15,6 +15,7 @@ import invariant from 'invariant';
 import RNCWebView from "./WebViewNativeComponent.android";
 import {
   defaultOriginWhitelist,
+  defaultDeeplinkWhitelist,
   defaultRenderError,
   defaultRenderLoading,
   useWebWiewLogic,
@@ -67,6 +68,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
   androidHardwareAccelerationDisabled = false,
   androidLayerType = "none",
   originWhitelist = defaultOriginWhitelist,
+  deeplinkWhitelist = defaultDeeplinkWhitelist,
   setBuiltInZoomControls = true,
   setDisplayZoomControls = false,
   nestedScrollEnabled = false,
@@ -111,6 +113,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>(({
     onOpenWindowProp,
     startInLoadingState,
     originWhitelist,
+    deeplinkWhitelist,
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
     validateMeta,

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -12,6 +12,7 @@ import codegenNativeCommandsUntyped from 'react-native/Libraries/Utilities/codeg
 import RNCWebView from "./WebViewNativeComponent.ios";
 import {
   defaultOriginWhitelist,
+  defaultDeeplinkWhitelist,
   defaultRenderError,
   defaultRenderLoading,
   useWebWiewLogic,
@@ -70,6 +71,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
   javaScriptEnabled = true,
   cacheEnabled = true,
   originWhitelist = defaultOriginWhitelist,
+  deeplinkWhitelist = defaultDeeplinkWhitelist,
   textInteractionEnabled= true,
   injectedJavaScript,
   injectedJavaScriptBeforeContentLoaded,
@@ -113,6 +115,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>(({
     onMessageProp,
     startInLoadingState,
     originWhitelist,
+    deeplinkWhitelist,
     onShouldStartLoadWithRequestProp,
     onShouldStartLoadWithRequestCallback,
     validateMeta,

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -17,7 +17,7 @@ import styles from './WebView.styles';
 
 const defaultOriginWhitelist = ['https://*'] as const;
 const defaultDeeplinkWhitelist = ['https://*'] as const;
-const defaultDeeplinkBlocklist = [`http:`, `file:`, `javascript:`] as const;
+const defaultDeeplinkBlocklist = [/^http:/, /^file:/, /^javascript:/] as const;
 
 const extractOrigin = (url: string): string => {
   const result = /^[A-Za-z][A-Za-z0-9+\-.]+:(\/\/)?[^/]*/.exec(url);
@@ -28,7 +28,7 @@ const stringWhitelistToRegex = (originWhitelist: string): string =>
   `^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`;
 
 const matchWithRegexList = (
-  compiledWhitelist: readonly string[],
+  compiledWhitelist: readonly string[] | readonly RegExp[],
   value: string,
 ) => {
   return compiledWhitelist.some(x => new RegExp(x).test(value));
@@ -64,8 +64,7 @@ const createOnShouldStartLoadWithRequest = (
     const { url, lockIdentifier, isTopFrame } = nativeEvent;
 
     if (!_passesWhitelist(compileWhitelist(originWhitelist), url)) {
-      const _deeplinkBlocklist = defaultDeeplinkBlocklist.map(stringWhitelistToRegex)
-      const foundMatchInBlocklist = matchWithRegexList(_deeplinkBlocklist, url)
+      const foundMatchInBlocklist = matchWithRegexList(defaultDeeplinkBlocklist, url)
 
       const _deeplinkWhitelist = (deepLinkWhitelist || []).map(stringWhitelistToRegex)
       const foundMatchInAllowlist = matchWithRegexList(_deeplinkWhitelist, url)

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -49,7 +49,7 @@ const _passesWhitelist = (
   const origin = extractOrigin(url);
   if (!origin) return false;
   if (origin !== new URL(url).origin) return null;
-  return matchWithRegexList(compiledWhitelist,  origin)
+  return matchWithRegexList(compiledWhitelist, origin)
 };
 
 const compileWhitelist = (

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -16,7 +16,7 @@ import {
 import styles from './WebView.styles';
 
 const defaultOriginWhitelist = ['https://*'] as const;
-const defaultDeeplinkWhitelist = ['https://*'] as const;
+const defaultDeeplinkWhitelist = ['https://'] as const;
 const defaultDeeplinkBlocklist = [/^http:/i, /^file:/i, /^javascript:/i] as const;
 
 const extractOrigin = (url: string): string => {
@@ -32,6 +32,14 @@ const matchWithRegexList = (
   value: string,
 ) => {
   return compiledRegexList.some(x => x.test(value));
+};
+
+const matchWithPrefixStringList = (
+  prefixes: readonly string[],
+  value: string,
+) => {
+  if (typeof value !== 'string') throw new Error(`value was not a string`)
+  return prefixes.some(x => value.startsWith(x));
 };
 
 const _passesWhitelist = (
@@ -71,8 +79,7 @@ const createOnShouldStartLoadWithRequest = (
       const foundMatchInBlocklist = matchWithRegexList(defaultDeeplinkBlocklist, url)
       if (!foundMatchInBlocklist) {
         /** Check if the url passes the dynamic deeplink allow list */
-        const _deeplinkWhitelist = (deepLinkWhitelist || []).map(stringWhitelistToRegex)
-        const foundMatchInAllowlist = matchWithRegexList(_deeplinkWhitelist, url)
+        const foundMatchInAllowlist = matchWithPrefixStringList(deepLinkWhitelist, url)
   
         if (foundMatchInAllowlist) {
           Linking.canOpenURL(url).then((supported) => {

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -55,7 +55,7 @@ const createOnShouldStartLoadWithRequest = (
 
     if (!_passesWhitelist(compileWhitelist(originWhitelist), url)) {
       Linking.canOpenURL(url).then((supported) => {
-        if (supported && isTopFrame && /^https:\/\//.test(url)) {
+        if (supported && isTopFrame) {
           return Linking.openURL(url);
         }
         console.warn(`Can't open url: ${url}`);

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -39,7 +39,7 @@ const matchWithPrefixStringList = (
   value: string,
 ) => {
   if (typeof value !== 'string') throw new Error(`value was not a string`)
-  return prefixes.some(x => value.startsWith(x));
+  return prefixes.some(x => String(x).length && String.prototype.startsWith.call(value, x));
 };
 
 const _passesWhitelist = (

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -24,18 +24,18 @@ const extractOrigin = (url: string): string => {
   return result === null ? '' : result[0];
 };
 
-const stringWhitelistToRegex = (originWhitelist: string): string =>
-  `^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`;
+const stringWhitelistToRegex = (originWhitelist: string): RegExp =>
+  new RegExp(`^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`);
 
 const matchWithRegexList = (
-  compiledWhitelist: readonly string[] | readonly RegExp[],
+  compiledRegexList: readonly RegExp[],
   value: string,
 ) => {
-  return compiledWhitelist.some(x => new RegExp(x).test(value));
+  return compiledRegexList.some(x => x.test(value));
 };
 
 const _passesWhitelist = (
-  compiledWhitelist: readonly string[],
+  compiledWhitelist: readonly RegExp[],
   url: string,
 ) => {
   const origin = extractOrigin(url);
@@ -46,7 +46,7 @@ const _passesWhitelist = (
 
 const compileWhitelist = (
   originWhitelist: readonly string[],
-): readonly string[] =>
+): readonly RegExp[] =>
   ['about:blank', ...(originWhitelist || [])].map(stringWhitelistToRegex);
 
 const createOnShouldStartLoadWithRequest = (

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -17,7 +17,7 @@ import styles from './WebView.styles';
 
 const defaultOriginWhitelist = ['https://*'] as const;
 const defaultDeeplinkWhitelist = ['https://*'] as const;
-const defaultDeeplinkBlocklist = [/^http:/, /^file:/, /^javascript:/] as const;
+const defaultDeeplinkBlocklist = [/^http:/i, /^file:/i, /^javascript:/i] as const;
 
 const extractOrigin = (url: string): string => {
   const result = /^[A-Za-z][A-Za-z0-9+\-.]+:(\/\/)?[^/]*/.exec(url);

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -888,7 +888,7 @@ export interface WebViewSharedProps extends ViewProps {
   /**
    * List of regex strings to allow being deep linked to. The strings allow
    * wildcards and get matched against the full URL.
-   * The default behavior is to not allow any.
+   * The default behavior is to only allow "https://*".
    */
     readonly deeplinkWhitelist?: string[];
 

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -886,6 +886,13 @@ export interface WebViewSharedProps extends ViewProps {
   readonly originWhitelist?: string[];
 
   /**
+   * List of regex strings to allow being deep linked to. The strings allow
+   * wildcards and get matched against the full URL.
+   * The default behavior is to not allow any.
+   */
+    readonly deeplinkWhitelist?: string[];
+
+  /**
    * Function that allows custom handling of any web view requests. Return
    * `true` from the function to continue loading the request and `false`
    * to stop loading. The `navigationType` is always `other` on android.

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -886,9 +886,9 @@ export interface WebViewSharedProps extends ViewProps {
   readonly originWhitelist?: string[];
 
   /**
-   * List of regex strings to allow being deep linked to. The strings allow
-   * wildcards and get matched against the full URL.
-   * The default behavior is to only allow "https://*".
+   * List of prefixes to allow being deep linked to. The strings do NOT allow
+   * wildcards and get matched against the full URL using "startsWith".
+   * The default behavior is to only allow "https://".
    */
     readonly deeplinkWhitelist?: string[];
 

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -151,6 +151,24 @@ describe('WebViewShared', () => {
       expect(Linking.openURL).not.toHaveBeenCalledWith(bad)
     });
 
+    test.each([
+      '',
+      [''],
+      '*'
+    ])('Linking.openURL with empty allow list should not allow passing', async (badList) => {
+      const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
+        loadRequest,
+        [],
+        [badList],
+      );
+      const bad = 'bitcoin:'
+      onShouldStartLoadWithRequest({ nativeEvent: { url: bad, isTopFrame: true, lockIdentifier: 1 } });
+      
+      await flushPromises();
+
+      expect(Linking.openURL).not.toHaveBeenCalledWith(bad)
+    });
+
     test('Linking.openURL with hardcoded blocklist should take priority over whitelist', async () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -130,13 +130,20 @@ describe('WebViewShared', () => {
       expect(Linking.openURL).toHaveBeenCalledWith(good)
     });
 
-    test('Linking.openURL with default blocklist', async () => {
+    test.each([
+      'javascript:alert(1)',
+      'jAvAsCrIpT:alert(1)',
+      'file:///Users/user/Documents/projects/index.html',
+      'fIlE:///Users/user/Documents/projects/index.html',
+      'http://google.com',
+      'hTtP://google.com'
+    ])('Linking.openURL with default blocklist %s', async (bad) => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         ['https://*'],
         ['bitcoin:*'],
       );
-      const bad = 'javascript:alert(1)'
+
       onShouldStartLoadWithRequest({ nativeEvent: { url: bad, isTopFrame: true, lockIdentifier: 1 } });
       
       await flushPromises();

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -70,7 +70,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
-        ['invalid://*'],
+        ['invalid://'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'invalid://example.com/', isTopFrame: true, lockIdentifier: 2 } });
@@ -101,7 +101,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
-        ['invalid://*'],
+        ['invalid://'],
         alwaysTrueOnShouldStartLoadWithRequest,
       );
 
@@ -119,7 +119,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         ['https://*'],
-        ['bitcoin:*'],
+        ['bitcoin:'],
       );
 
       const good = 'bitcoin:175tWpb8K1S7NmH4Zx6rewF9WQrcZv245W?amount=50&label=Luke-Jr&message=Donation%20for%20project%20xyz'
@@ -141,7 +141,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         ['https://*'],
-        ['bitcoin:*'],
+        ['bitcoin:'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: bad, isTopFrame: true, lockIdentifier: 1 } });
@@ -155,7 +155,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         [],
-        ['javascript:*'],
+        ['javascript:'],
       );
       const bad = 'javascript:alert(1)'
       onShouldStartLoadWithRequest({ nativeEvent: { url: bad, isTopFrame: true, lockIdentifier: 1 } });
@@ -185,7 +185,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         ['https://*'],
-        ['git+https:*', 'fakehttps:*'],
+        ['git+https:', 'fakehttps:'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/', isTopFrame: true, lockIdentifier: 1 } });
@@ -221,7 +221,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
           loadRequest,
           ['plus+https://*', 'DOT.https://*', 'dash-https://*', '0invalid://*', '+invalid://*'],
-          ['0invalid:*', '+invalid:*', 'FAKE+plus+https:*'],
+          ['0invalid:', '+invalid:', 'FAKE+plus+https:'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'plus+https://www.example.com/',  isTopFrame: true, lockIdentifier: 1 } });

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -2,6 +2,7 @@ import { Linking } from 'react-native';
 
 import {
   defaultOriginWhitelist,
+  defaultDeeplinkWhitelist,
   createOnShouldStartLoadWithRequest,
 } from '../WebViewShared';
 
@@ -35,6 +36,10 @@ describe('WebViewShared', () => {
     expect(defaultOriginWhitelist).toMatchSnapshot();
   });
 
+  test('exports defaultDeeplinkWhitelist', () => {
+    expect(defaultDeeplinkWhitelist).toMatchSnapshot();
+  });
+
   describe('createOnShouldStartLoadWithRequest', () => {
     const alwaysTrueOnShouldStartLoadWithRequest = (nativeEvent) => {
       return true;
@@ -50,6 +55,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
+        defaultDeeplinkWhitelist,
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'https://www.example.com/', lockIdentifier: 1 } });
@@ -64,6 +70,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
+        defaultDeeplinkWhitelist,
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'invalid://example.com/', lockIdentifier: 2 } });
@@ -78,6 +85,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
+        defaultDeeplinkWhitelist,
         alwaysTrueOnShouldStartLoadWithRequest,
       );
 
@@ -93,6 +101,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
+        defaultDeeplinkWhitelist,
         alwaysTrueOnShouldStartLoadWithRequest,
       );
 
@@ -111,6 +120,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
+        defaultDeeplinkWhitelist,
         alwaysFalseOnShouldStartLoadWithRequest,
       );
 

--- a/src/__tests__/__snapshots__/WebViewShared-test.js.snap
+++ b/src/__tests__/__snapshots__/WebViewShared-test.js.snap
@@ -6,3 +6,9 @@ Array [
   "https://*",
 ]
 `;
+
+exports[`WebViewShared exports defaultDeeplinkWhitelist 1`] = `
+Array [
+  "https://*",
+]
+`;

--- a/src/__tests__/__snapshots__/WebViewShared-test.js.snap
+++ b/src/__tests__/__snapshots__/WebViewShared-test.js.snap
@@ -2,7 +2,6 @@
 
 exports[`WebViewShared exports defaultOriginWhitelist 1`] = `
 Array [
-  "http://*",
   "https://*",
 ]
 `;

--- a/src/__tests__/__snapshots__/WebViewShared-test.js.snap
+++ b/src/__tests__/__snapshots__/WebViewShared-test.js.snap
@@ -8,6 +8,6 @@ Array [
 
 exports[`WebViewShared exports defaultDeeplinkWhitelist 1`] = `
 Array [
-  "https://*",
+  "https://",
 ]
 `;


### PR DESCRIPTION
This PR removes the restriction of only allowing to open up "https" URLs, and instead allows the webview to open up "bitcoin:" deeplinks.