### PR TITLE
fix: force the usage of actual protocol scheme

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -34,7 +34,7 @@ const matchWithRegexList = (
   return compiledRegexList.some(x => x.test(value));
 };
 
-const matchWithPrefixStringList = (
+const matchWithStringList = (
   prefixes: readonly string[],
   value: string,
 ) => {
@@ -90,10 +90,10 @@ const createOnShouldStartLoadWithRequest = (
       /* Check that the protocol was properly parsed */
       if (protocol !== null) {
         /** Check if the protocol passes the hardcoded deeplink blocklist */
-        const foundMatchInBlocklist = matchWithPrefixStringList(defaultDeeplinkBlocklist, protocol)
+        const foundMatchInBlocklist = matchWithStringList(defaultDeeplinkBlocklist, protocol)
         if (!foundMatchInBlocklist) {
           /** Check if the protocol passes the dynamic deeplink allow list */
-          const foundMatchInAllowlist = matchWithPrefixStringList(deepLinkWhitelist, protocol)
+          const foundMatchInAllowlist = matchWithStringList(deepLinkWhitelist, protocol)
     
           if (foundMatchInAllowlist) {
             Linking.canOpenURL(url).then((supported) => {
@@ -106,8 +106,10 @@ const createOnShouldStartLoadWithRequest = (
               console.warn('Error opening URL: ', e);
             });
           } else {
-            console.warn(`Failed to pass default block list or whitelist deep link url: ${url}`);
+            console.warn(`Failed to pass whitelist for deep link url: ${url}`);
           }
+        } else {
+          console.warn(`Failed to pass default block list for deep link url: ${url}`);
         }
       }
 

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -48,7 +48,12 @@ const _passesWhitelist = (
 ) => {
   const origin = extractOrigin(url);
   if (!origin) return false;
-  if (origin !== new URL(url).origin) return null;
+  try {
+    const decodedUrl = new URL(url)
+    if (origin !== decodedUrl.origin) return null;
+  } catch {
+    return false
+  }
   return matchWithRegexList(compiledWhitelist, origin)
 };
 

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -39,7 +39,7 @@ const matchWithPrefixStringList = (
   value: string,
 ) => {
   if (typeof value !== 'string') throw new Error(`value was not a string`)
-  return prefixes.some(x => String(x).length && String.prototype.startsWith.call(value, x));
+  return Array.prototype.includes.call(prefixes, value)
 };
 
 const _passesWhitelist = (

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -886,9 +886,8 @@ export interface WebViewSharedProps extends ViewProps {
   readonly originWhitelist?: string[];
 
   /**
-   * List of prefixes to allow being deep linked to. The strings do NOT allow
-   * wildcards and get matched against the full URL using "startsWith".
-   * The default behavior is to only allow "https://".
+   * List of protocol schemes to allow being deep linked to. This requires
+   * an exact match. The default behavior is to only allow "https:".
    */
     readonly deeplinkWhitelist?: string[];
 

--- a/src/__tests__/WebViewShared-test.js
+++ b/src/__tests__/WebViewShared-test.js
@@ -70,7 +70,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
-        ['invalid://'],
+        ['invalid:'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'invalid://example.com/', isTopFrame: true, lockIdentifier: 2 } });
@@ -101,7 +101,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
         loadRequest,
         defaultOriginWhitelist,
-        ['invalid://'],
+        ['invalid:'],
         alwaysTrueOnShouldStartLoadWithRequest,
       );
 
@@ -239,7 +239,7 @@ describe('WebViewShared', () => {
       const onShouldStartLoadWithRequest = createOnShouldStartLoadWithRequest(
           loadRequest,
           ['plus+https://*', 'DOT.https://*', 'dash-https://*', '0invalid://*', '+invalid://*'],
-          ['0invalid:', '+invalid:', 'FAKE+plus+https:'],
+          ['0invalid:', '+invalid:', 'fake+plus+https:'],
       );
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'plus+https://www.example.com/',  isTopFrame: true, lockIdentifier: 1 } });
@@ -270,7 +270,7 @@ describe('WebViewShared', () => {
 
       await flushPromises();
 
-      expect(Linking.openURL).toHaveBeenLastCalledWith('0invalid://www.example.com/');
+      expect(Linking.openURL).not.toHaveBeenLastCalledWith('0invalid://www.example.com/');
       // (new URL('DOT.https://www.example.com/')).origin is null so it doesn't pass _passesWhitelist
       expect(loadRequest).toHaveBeenLastCalledWith(false, '0invalid://www.example.com/', 4);
 
@@ -278,7 +278,7 @@ describe('WebViewShared', () => {
       
       await flushPromises();
 
-      expect(Linking.openURL).toHaveBeenLastCalledWith('+invalid://www.example.com/');
+      expect(Linking.openURL).not.toHaveBeenLastCalledWith('+invalid://www.example.com/');
       expect(loadRequest).toHaveBeenLastCalledWith(false, '+invalid://www.example.com/', 5);
 
       onShouldStartLoadWithRequest({ nativeEvent: { url: 'FAKE+plus+https://www.example.com/',  isTopFrame: true, lockIdentifier: 6 } });

--- a/src/__tests__/__snapshots__/WebViewShared-test.js.snap
+++ b/src/__tests__/__snapshots__/WebViewShared-test.js.snap
@@ -8,6 +8,6 @@ Array [
 
 exports[`WebViewShared exports defaultDeeplinkWhitelist 1`] = `
 Array [
-  "https://",
+  "https:",
 ]
 `;


### PR DESCRIPTION
This PR addresses https://github.com/ExodusMovement/react-native-webview/pull/21#discussion_r1619865694 to harden the library against misuse, essentially disallowing implicit wildcards by the usage of `startsWith` and disallowing invalid protocols.