### PR TITLE
fix: whitelist validation for iframes

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -41,9 +41,13 @@ const _passesWhitelist = (
   compiledWhitelist: readonly RegExp[],
   url: string,
 ) => {
-  const { origin } = new URL(url);
-  if (!origin) return false;
-  return matchWithRegexList(compiledWhitelist, origin)
+  try {
+    const { origin } = new URL(url)
+    if (!origin) return null;
+    return matchWithRegexList(compiledWhitelist, origin)
+  } catch {
+    return false
+  }
 };
 
 const compileWhitelist = (

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -19,11 +19,6 @@ const defaultOriginWhitelist = ['https://*'] as const;
 const defaultDeeplinkWhitelist = ['https:'] as const;
 const defaultDeeplinkBlocklist = [`http:`, `file:`, `javascript:`] as const;
 
-const extractOrigin = (url: string): string => {
-  const result = /^[A-Za-z][A-Za-z0-9+\-.]+:(\/\/)?[^/]*/.exec(url);
-  return result === null ? '' : result[0];
-};
-
 const stringWhitelistToRegex = (originWhitelist: string): RegExp =>
   new RegExp(`^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`);
 
@@ -46,14 +41,8 @@ const _passesWhitelist = (
   compiledWhitelist: readonly RegExp[],
   url: string,
 ) => {
-  const origin = extractOrigin(url);
+  const { origin } = new URL(url);
   if (!origin) return false;
-  try {
-    const decodedUrl = new URL(url)
-    if (origin !== decodedUrl.origin) return null;
-  } catch {
-    return false
-  }
   return matchWithRegexList(compiledWhitelist, origin)
 };
 


### PR DESCRIPTION
## Summary

This change fixes a specific bug content in https://pump.fun

pump.fun has a screen with a chart (https://pump.fun/qAVkvgHYsCWyhdcrqQs8RdLN3cJAMJVLrAtu5Copump) which is an iframe, this iframe has the URL starting with `blob`, so the `extractOrigin` function is extracting wrong the origin from the URL.
since I noticed that this function is redundant, I'm changing to get the origin from the `URL` object and checking it against the `origingWhitelist` 

## Test plan

```js
    <WebView
      style={styles.container}
      source={{ uri: 'https://pump.fun/' }}
      originWhitelist={['*']}
    />
```