### PR TITLE
feat: return only falsy values in passesWhitelist function

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -43,8 +43,7 @@ const _passesWhitelist = (
 ) => {
   try {
     const { origin } = new URL(url)
-    if (!origin) return null;
-    return matchWithRegexList(compiledWhitelist, origin)
+    return origin && matchWithRegexList(compiledWhitelist, origin)
   } catch {
     return false
   }


### PR DESCRIPTION
Modify `_passesWhitelist` to return only `true` or `false` instead of null

ref: https://github.com/ExodusMovement/magic-eden/pull/3001#issuecomment-2263096833