### PR TITLE
feat: allow veriff enterprise domains for camera access

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -171,6 +171,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   public RNCWebViewManager() {
     cameraPermissionOriginWhitelist = new HashSet<>();
     cameraPermissionOriginWhitelist.add("https://alchemy.veriff.com/");
+    cameraPermissionOriginWhitelist.add("https://magic.veriff.me/");
 
     mWebViewConfig = new WebViewConfig() {
       public void configWebView(WebView webView) {


### PR DESCRIPTION
We recently changed API endpoints for Veriff to use their enterprise API. However, that API returns session URLs with another endpoint so when requesting camera access, it doesn't work.