### PR TITLE
chore: ignore android gradle on package release

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "files": [
     "android",
+    "!android/.gradle",
     "apple",
     "ios",
     "lib",


### PR DESCRIPTION
## summary

Do not publish `android/.gradle` on package release

## Testplan

- [x] run `npm pack`
- [x] `android/.gradle` should not be included in packed file 