### PR TITLE
fix: use WKSecurityOrigin in place of absoluteUrl

### DIFF
--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -582,8 +582,13 @@ RCTAutoInsetsProtocol>
 #endif
 
 - (NSMutableDictionary<NSString *, id> *)baseEventWithScriptMessage:(WKScriptMessage *)message {
+    WKSecurityOrigin *securityOrigin = message.frameInfo.securityOrigin;
+    NSString *protocol = securityOrigin.protocol;
+    NSString *host = securityOrigin.host;
+
+    NSString *messageOriginURL = [NSString stringWithFormat:@"%@://%@", protocol, host];
+    
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
-    NSString *messageOriginURL = message.frameInfo.request.URL.absoluteString ?: @"";
     event[@"url"] = messageOriginURL;
     return event;
 }


### PR DESCRIPTION
Follow up from security [review](https://github.com/ExodusMovement/exodus-mobile/pull/21623#issuecomment-2328442373) to use `WKSecurityOrigin` which only sends the `origin` without extra params/queries towards hardening webview security

follow test plan from [PR](https://github.com/ExodusMovement/exodus-mobile/pull/21623)