### PR TITLE
fix: slice title to max 512 characters

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -190,7 +190,7 @@ export const useWebWiewLogic = ({
   const extractMeta = (nativeEvent: WebViewNativeEvent): WebViewNativeEvent => ({
     url: String(nativeEvent.url),
     loading: Boolean(nativeEvent.loading),
-    title: String(nativeEvent.title),
+    title: String(nativeEvent.title).slice(0, 512),
     canGoBack: Boolean(nativeEvent.canGoBack),
     canGoForward: Boolean(nativeEvent.canGoForward),
     lockIdentifier: Number(nativeEvent.lockIdentifier),


### PR DESCRIPTION
This PR truncates the title to 512 characters.