### PR TITLE
fix: enforce webview camera permission whitelist for ios

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -166,8 +166,6 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected @Nullable String mDownloadingMessage = null;
   protected @Nullable String mLackPermissionToDownloadMessage = null;
 
-  private Set<String> cameraPermissionWhitelist = new HashSet<>();
-
   public RNCWebViewManager() {
     mWebViewConfig = new WebViewConfig() {
       public void configWebView(WebView webView) {
@@ -235,7 +233,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       whitelistSet.add(whitelist.getString(i));
     }
 
-    webView.setCameraPermissionWhitelist(whitelistSet);
+    mWebChromeClient.setCameraPermissionWhitelist(whitelistSet);
   }
 
   @ReactProp(name = "javaScriptEnabled")
@@ -1004,10 +1002,15 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     // True if protected media should be allowed, false otherwise
     protected boolean mAllowsProtectedMedia = false;
+    private Set<String> cameraPermissionWhitelist = new HashSet<>();
 
     public RNCWebChromeClient(ReactContext reactContext, WebView webView) {
       this.mReactContext = reactContext;
       this.mWebView = webView;
+    }
+
+    public void setCameraPermissionWhitelist(Set<String> whitelist) {
+      this.cameraPermissionWhitelist = whitelist;
     }
 
     @Override
@@ -1085,7 +1088,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       for (String requestedResource : request.getResources()) {
         String androidPermission = null;
 
-        if (cameraPermissionWhitelist.contains(originHost)) {
+        if (this.cameraPermissionWhitelist.contains(originHost)) {
           if (requestedResource.equals(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
             androidPermission = Manifest.permission.CAMERA;
           } else if (requestedResource.equals(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {

--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -166,13 +166,9 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
   protected @Nullable String mDownloadingMessage = null;
   protected @Nullable String mLackPermissionToDownloadMessage = null;
 
-  private static Set<String> cameraPermissionOriginWhitelist;
+  private Set<String> cameraPermissionWhitelist = new HashSet<>();
 
   public RNCWebViewManager() {
-    cameraPermissionOriginWhitelist = new HashSet<>();
-    cameraPermissionOriginWhitelist.add("https://alchemy.veriff.com/");
-    cameraPermissionOriginWhitelist.add("https://magic.veriff.me/");
-
     mWebViewConfig = new WebViewConfig() {
       public void configWebView(WebView webView) {
       }
@@ -230,6 +226,16 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   private String getLackPermissionToDownloadMessage() {
     return  mDownloadingMessage == null ? DEFAULT_LACK_PERMISSION_TO_DOWNLOAD_MESSAGE : mLackPermissionToDownloadMessage;
+  }
+
+  @ReactProp(name = "cameraPermissionWhitelist")
+  public void setCameraPermissionWhitelist(RNCWebView webView, ReadableArray whitelist) {
+    Set<String> whitelistSet = new HashSet<>();
+    for (int i = 0; i < whitelist.size(); i++) {
+      whitelistSet.add(whitelist.getString(i));
+    }
+
+    webView.setCameraPermissionWhitelist(whitelistSet);
   }
 
   @ReactProp(name = "javaScriptEnabled")
@@ -1065,11 +1071,21 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       grantedPermissions = new ArrayList<>();
 
       ArrayList<String> requestedAndroidPermissions = new ArrayList<>();
+      String originUrl = request.getOrigin().toString();
+      String originHost;
+
+      try {
+        URL url = new URL(originUrl);
+        originHost = url.getHost();
+      } catch (MalformedURLException e) {
+        request.deny();
+        return;
+      }
 
       for (String requestedResource : request.getResources()) {
         String androidPermission = null;
 
-        if (cameraPermissionOriginWhitelist.contains(request.getOrigin().toString())) {
+        if (cameraPermissionWhitelist.contains(originHost)) {
           if (requestedResource.equals(PermissionRequest.RESOURCE_VIDEO_CAPTURE)) {
             androidPermission = Manifest.permission.CAMERA;
           } else if (requestedResource.equals(PermissionRequest.RESOURCE_AUDIO_CAPTURE)) {

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -71,6 +71,7 @@ RCTAutoInsetsProtocol>
 @property (nonatomic, strong) WKUserScript *postMessageScript;
 @property (nonatomic, strong) WKUserScript *atStartScript;
 @property (nonatomic, strong) WKUserScript *atEndScript;
+@property (nonatomic, strong) NSArray<NSString *> *cameraPermissionWhitelist;
 @end
 
 @implementation RNCWebView
@@ -97,15 +98,6 @@ RCTAutoInsetsProtocol>
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
   BOOL _savedAutomaticallyAdjustsScrollIndicatorInsets;
 #endif
-}
-
-+ (void)initialize {
-    if (self == [RNCWebView class]) {
-        cameraPermissionWhitelist = [NSSet setWithArray:@[
-            @"alchemy.veriff.com",
-            @"magic.veriff.me"
-        ]];
-    }
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -1064,7 +1056,7 @@ RCTAutoInsetsProtocol>
                         initiatedByFrame:(WKFrameInfo *)frame
                                     type:(WKMediaCaptureType)type
                          decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {
-  if (![cameraPermissionWhitelist containsObject:origin.host]) {
+  if (![self.cameraPermissionWhitelist containsObject:origin.host]) {
     decisionHandler(WKPermissionDecisionDeny);
     return;
   }

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -22,6 +22,7 @@ static NSString *const HistoryShimName = @"ReactNativeHistoryShim";
 static NSString *const MessageHandlerName = @"ReactNativeWebView";
 static NSURLCredential* clientAuthenticationCredential;
 static NSDictionary* customCertificatesForHost;
+static NSSet *cameraPermissionWhitelist;
 
 NSString *const CUSTOM_SELECTOR = @"_CUSTOM_SELECTOR_";
 
@@ -96,6 +97,15 @@ RCTAutoInsetsProtocol>
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
   BOOL _savedAutomaticallyAdjustsScrollIndicatorInsets;
 #endif
+}
+
++ (void)initialize {
+    if (self == [RNCWebView class]) {
+        cameraPermissionWhitelist = [NSSet setWithArray:@[
+            @"alchemy.veriff.com",
+            @"magic.veriff.me"
+        ]];
+    }
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -1054,6 +1064,11 @@ RCTAutoInsetsProtocol>
                         initiatedByFrame:(WKFrameInfo *)frame
                                     type:(WKMediaCaptureType)type
                          decisionHandler:(void (^)(WKPermissionDecision decision))decisionHandler {
+  if (![cameraPermissionWhitelist containsObject:origin.host]) {
+    decisionHandler(WKPermissionDecisionDeny);
+    return;
+  }
+
   if (_mediaCapturePermissionGrantType == RNCWebViewPermissionGrantType_GrantIfSameHost_ElsePrompt || _mediaCapturePermissionGrantType == RNCWebViewPermissionGrantType_GrantIfSameHost_ElseDeny) {
     if ([origin.host isEqualToString:webView.URL.host]) {
       decisionHandler(WKPermissionDecisionGrant);

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -78,6 +78,7 @@ RCT_EXPORT_VIEW_PROPERTY(pagingEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(cacheEnabled, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(allowsLinkPreview, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(basicAuthCredential, NSDictionary)
+RCT_EXPORT_VIEW_PROPERTY(cameraPermissionWhitelist, NSArray)
 
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 110000 /* __IPHONE_11_0 */
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -20,7 +20,7 @@ import {
   defaultRenderLoading,
   useWebWiewLogic,
   versionPasses,
-  normalizeWhitelist,
+  removeHttpsFromOrigins,
 } from './WebViewShared';
 import {
   AndroidWebViewProps,
@@ -209,7 +209,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
   const webView = <NativeWebView
     key="webViewKey"
     {...otherProps}
-    cameraPermissionWhitelist={normalizeWhitelist(cameraPermissionWhitelist)}
+    cameraPermissionWhitelist={removeHttpsFromOrigins(cameraPermissionWhitelist)}
     messagingEnabled={typeof onMessageProp === 'function'}
     messagingModuleName={messagingModuleName}
 

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -20,6 +20,7 @@ import {
   defaultRenderLoading,
   useWebWiewLogic,
   versionPasses,
+  normalizeWhitelist,
 } from './WebViewShared';
 import {
   AndroidWebViewProps,
@@ -67,6 +68,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
     scalesPageToFit = true,
     saveFormDataDisabled = false,
     cacheEnabled = true,
+    cameraPermissionWhitelist = [],
     androidHardwareAccelerationDisabled = false,
     androidLayerType = "none",
     originWhitelist = defaultOriginWhitelist,
@@ -207,6 +209,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
   const webView = <NativeWebView
     key="webViewKey"
     {...otherProps}
+    cameraPermissionWhitelist={normalizeWhitelist(cameraPermissionWhitelist)}
     messagingEnabled={typeof onMessageProp === 'function'}
     messagingModuleName={messagingModuleName}
 

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -17,6 +17,7 @@ import {
   defaultRenderLoading,
   useWebWiewLogic,
   versionPasses,
+  normalizeWhitelist,
 } from './WebViewShared';
 import {
   IOSWebViewProps,
@@ -72,6 +73,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
   const {
     javaScriptEnabled = true,
     cacheEnabled = true,
+    cameraPermissionWhitelist = [],
     originWhitelist = defaultOriginWhitelist,
     deeplinkWhitelist = defaultDeeplinkWhitelist,
     textInteractionEnabled= true,
@@ -190,6 +192,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
       enableApplePay={enableApplePay}
       javaScriptEnabled={javaScriptEnabled}
       cacheEnabled={cacheEnabled}
+      cameraPermissionWhitelist={normalizeWhitelist(cameraPermissionWhitelist)}
       dataDetectorTypes={dataDetectorTypes}
       useSharedProcessPool={useSharedProcessPool}
       textInteractionEnabled={textInteractionEnabled}

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -17,7 +17,7 @@ import {
   defaultRenderLoading,
   useWebWiewLogic,
   versionPasses,
-  normalizeWhitelist,
+  removeHttpsFromOrigins,
 } from './WebViewShared';
 import {
   IOSWebViewProps,
@@ -192,7 +192,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
       enableApplePay={enableApplePay}
       javaScriptEnabled={javaScriptEnabled}
       cacheEnabled={cacheEnabled}
-      cameraPermissionWhitelist={normalizeWhitelist(cameraPermissionWhitelist)}
+      cameraPermissionWhitelist={removeHttpsFromOrigins(cameraPermissionWhitelist)}
       dataDetectorTypes={dataDetectorTypes}
       useSharedProcessPool={useSharedProcessPool}
       textInteractionEnabled={textInteractionEnabled}

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -316,3 +316,7 @@ export const versionPasses = (version: string | undefined, minimum: string | und
   }
   return true // equals
 }
+
+export const normalizeWhitelist = (whitelist: string[]) => {
+  return whitelist.map((origin) => origin.replace('https://', ''))
+}

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -317,6 +317,6 @@ export const versionPasses = (version: string | undefined, minimum: string | und
   return true // equals
 }
 
-export const normalizeWhitelist = (whitelist: string[]) => {
+export const removeHttpsFromOrigins = (whitelist: string[]) => {
   return whitelist.map((origin) => origin.replace('https://', ''))
 }

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -229,6 +229,7 @@ export interface BasicAuthCredential {
 
 export interface CommonNativeWebViewProps extends ViewProps {
   cacheEnabled?: boolean;
+  cameraPermissionWhitelist?: string[];
   incognito?: boolean;
   injectedJavaScript?: string;
   injectedJavaScriptBeforeContentLoaded?: string;
@@ -787,6 +788,13 @@ export interface WebViewSharedProps extends ViewProps {
    */
   javaScriptEnabled?: boolean;
 
+
+  /**
+   * Defines a list of domain origins that can access camera.
+   */
+
+  readonly cameraPermissionWhitelist?: string[];
+
   /**
    * Stylesheet object to set the style of the container view.
    */
@@ -889,7 +897,7 @@ export interface WebViewSharedProps extends ViewProps {
    * List of protocol schemes to allow being deep linked to. This requires
    * an exact match. The default behavior is to only allow "https:".
    */
-    readonly deeplinkWhitelist?: string[];
+  readonly deeplinkWhitelist?: string[];
 
   /**
    * Function that allows custom handling of any web view requests. Return


### PR DESCRIPTION
# Summary

This PR enhances security by restricting media capture permissions (camera) in RN WebView for iOS to a predefined whitelist of trusted domains. It ensures that only approved origins (`alchemy.veriff.com` and `magic.veriff.me`) are granted access. We are already doing the same for Android.

More context: https://github.com/ExodusMovement/exodus-mobile/pull/24202#pullrequestreview-2617868370