### PR TITLE
chore: exclude android/build from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   "files": [
     "android",
     "!android/.gradle",
+    "!android/build",
     "apple",
     "ios",
     "lib",


### PR DESCRIPTION
ensure we `android/build` is always excluded from npm package.