### PR TITLE
feat: better handle invalid JSON

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -236,11 +236,15 @@ export const useWebWiewLogic = ({
     if (!passesWhitelistUse(nativeEvent.url)) return;
 
     // TODO: can/should we perform any other validation?
+    try {
+      const parsedData = JSON.parse(nativeEvent.data);
+      const data = JSON.stringify(validateData(parsedData));
+      const meta = validateMeta(extractMeta(nativeEvent));
 
-    const data = JSON.stringify(validateData(JSON.parse(nativeEvent.data)));
-    const meta = validateMeta(extractMeta(nativeEvent));
-
-    onMessageProp?.({ ...meta, data });
+      onMessageProp?.({ ...meta, data });
+    } catch (err) {
+      console.error('Error parsing WebView message', err);
+    }
   }, [onMessageProp, passesWhitelistUse, validateData, validateMeta]);
 
   const onLoadingProgress = useCallback((event: WebViewProgressEvent) => {


### PR DESCRIPTION
The issue discovered in https://github.com/ExodusMovement/exodus-mobile/pull/24709#pullrequestreview-2667702215. Some dApp may send non-JSON content inside the `nativeEvent.data`. For example, https://minswap.org is sending this:
```
{
    "target": 9037,
    "url": "https://minswap.org/",
    "data": "ready",
    "title": "Minswap DEX | Multi-pool decentralized exchange on Cardano",
    "canGoBack": false,
    "loading": false,
    "canGoForward": false
}
```

The fix is needed to unblock updating `@exodus/web3-cardano` with https://github.com/ExodusMovement/assets/pull/5312, which is needed for the Headless update in Mobile

## Testing

- [ ] Mobile Web3 Browser should not crash when opening https://minswap.org