### PR TITLE
feat: allow downloads only from trusted origins and with approved file types

### DIFF
--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -71,6 +71,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
     androidLayerType = "none",
     originWhitelist = defaultOriginWhitelist,
     deeplinkWhitelist = defaultDeeplinkWhitelist,
+    downloadOriginWhitelist = [],
     setBuiltInZoomControls = true,
     setDisplayZoomControls = false,
     nestedScrollEnabled = false,
@@ -108,6 +109,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
   }, []);
 
   const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onLoadingError, onLoadingFinish, onLoadingProgress, onOpenWindow, passesWhitelist } = useWebWiewLogic({
+    downloadOriginWhitelist,
     onLoad,
     onError,
     onLoadEnd,

--- a/src/WebView.android.tsx
+++ b/src/WebView.android.tsx
@@ -71,7 +71,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
     androidLayerType = "none",
     originWhitelist = defaultOriginWhitelist,
     deeplinkWhitelist = defaultDeeplinkWhitelist,
-    downloadOriginWhitelist = [],
+    downloadWhitelist = [],
     setBuiltInZoomControls = true,
     setDisplayZoomControls = false,
     nestedScrollEnabled = false,
@@ -109,7 +109,7 @@ const WebViewComponent = forwardRef<{}, AndroidWebViewProps>((props, ref) => {
   }, []);
 
   const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onLoadingError, onLoadingFinish, onLoadingProgress, onOpenWindow, passesWhitelist } = useWebWiewLogic({
-    downloadOriginWhitelist,
+    downloadWhitelist,
     onLoad,
     onError,
     onLoadEnd,

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -74,6 +74,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
     cacheEnabled = true,
     originWhitelist = defaultOriginWhitelist,
     deeplinkWhitelist = defaultDeeplinkWhitelist,
+    downloadOriginWhitelist = [],
     textInteractionEnabled= true,
     injectedJavaScript,
     injectedJavaScriptBeforeContentLoaded,
@@ -111,6 +112,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
   }, []);
 
   const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onLoadingError, onLoadingFinish, onLoadingProgress } = useWebWiewLogic({
+    downloadOriginWhitelist,
     onLoad,
     onError,
     onLoadEnd,

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -74,7 +74,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
     cacheEnabled = true,
     originWhitelist = defaultOriginWhitelist,
     deeplinkWhitelist = defaultDeeplinkWhitelist,
-    downloadOriginWhitelist = [],
+    downloadWhitelist = [],
     textInteractionEnabled= true,
     injectedJavaScript,
     injectedJavaScriptBeforeContentLoaded,
@@ -112,7 +112,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
   }, []);
 
   const { onLoadingStart, onShouldStartLoadWithRequest, onMessage, viewState, setViewState, lastErrorEvent, onLoadingError, onLoadingFinish, onLoadingProgress } = useWebWiewLogic({
-    downloadOriginWhitelist,
+    downloadWhitelist,
     onLoad,
     onError,
     onLoadEnd,

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -284,7 +284,7 @@ export const useWebWiewLogic = ({
       const validatedData = validateData(parsedData);
 
       if (!isDownloadMessageAllowed({
-        data: parsedData.data,
+        data: (validatedData as { data?: string })?.data ?? '',
         downloadWhitelist,
         url: nativeEvent.url,
       })) {

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -87,13 +87,7 @@ const isDownloadMessageAllowed = ({
     return false;
   }
 
-  const matchingRule = downloadWhitelist.find(rule => {
-    const ruleOriginRegex = stringWhitelistToRegex(rule.origin);
-
-    return ruleOriginRegex.test(origin) && rule.allowedFileExtensions.includes(fileExtension);
-  });
-
-  return Boolean(matchingRule);
+  return Boolean(downloadWhitelist.find((rule) => rule.origin === origin && rule.allowedFileExtensions.includes(fileExtension)));
 };
 
 const urlToProtocolScheme = (url: string): string | null => {

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -45,7 +45,7 @@ const _passesWhitelist = (
     const { href, origin } = new URL(url)
 
     if (origin && origin !== 'null') {
-      return matchWithRegexList(compiledWhitelist, origin);
+      return matchWithRegexList(compiledWhitelist, origin)
     }
 
     return matchWithRegexList(compiledWhitelist, href)

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -45,7 +45,7 @@ const _passesWhitelist = (
     const { href, origin } = new URL(url)
 
     if (origin && origin !== 'null') {
-      return matchWithRegexList(compiledWhitelist, origin)
+      return matchWithRegexList(compiledWhitelist, origin);
     }
 
     return matchWithRegexList(compiledWhitelist, href)
@@ -56,9 +56,8 @@ const _passesWhitelist = (
 
 const compileWhitelist = (
   originWhitelist: readonly string[],
-  defaultEntries: readonly string[] = ['about:blank'],
 ): readonly RegExp[] =>
-  [...defaultEntries, ...(originWhitelist || [])].map(stringWhitelistToRegex);
+['about:blank', ...(originWhitelist || [])].map(stringWhitelistToRegex);
 
 const isDownloadMessageAllowed = ({
   data,
@@ -277,9 +276,7 @@ export const useWebWiewLogic = ({
 
   const onMessage = useCallback((event: WebViewMessageEvent) => {
     const { nativeEvent } = event;
-    const { url } = nativeEvent;
-
-    if (!passesWhitelistUse(url)) return;
+    if (!passesWhitelistUse(nativeEvent.url)) return;
 
     // TODO: can/should we perform any other validation?
     try {
@@ -289,7 +286,7 @@ export const useWebWiewLogic = ({
       if (!isDownloadMessageAllowed({
         data: parsedData.data,
         downloadWhitelist,
-        url,
+        url: nativeEvent.url,
       })) {
         console.warn('Download request rejected: origin not in download whitelist or file extension not allowed');
         return;

--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -87,7 +87,7 @@ const isDownloadMessageAllowed = ({
     return false;
   }
 
-  return Boolean(downloadWhitelist.find((rule) => rule.origin === origin && rule.allowedFileExtensions.includes(fileExtension)));
+  return Boolean(downloadWhitelist.find((rule) => rule.origin === origin && [rule.allowedFileExtensions].flat().includes(fileExtension)));
 };
 
 const urlToProtocolScheme = (url: string): string | null => {

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -788,13 +788,18 @@ export interface WebViewSharedProps extends ViewProps {
    */
   javaScriptEnabled?: boolean;
 
-  /**
-   * List of origin strings that are allowed to send download data through postMessage.
-   * The strings allow wildcards and get matched against *just* the origin (not the full URL).
-   * If a download request comes from an origin not in this whitelist, it will be ignored.
-   * The default whitelisted origins are empty array [].
-   */
-  readonly downloadOriginWhitelist?: string[];
+/**
+ * List of objects defining the origins allowed to send download data through postMessage.
+ * Each object contains:
+ *   - `origin`: The allowed origin (matches against the origin, not the full URL).
+ *   - `allowedFileExtensions`: An array of allowed file extensions for downloads from that origin (required).
+ * If a download request comes from an origin not in this whitelist, or with a disallowed file extension, it will be ignored.
+ * The default whitelist is an empty array [].
+ */
+  readonly downloadWhitelist?: {
+    origin: string;
+    allowedFileExtensions: string[];
+  }[];
 
   /**
    * Defines a list of domain origins that can access camera.

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -788,11 +788,17 @@ export interface WebViewSharedProps extends ViewProps {
    */
   javaScriptEnabled?: boolean;
 
+  /**
+   * List of origin strings that are allowed to send download data through postMessage.
+   * The strings allow wildcards and get matched against *just* the origin (not the full URL).
+   * If a download request comes from an origin not in this whitelist, it will be ignored.
+   * The default whitelisted origins are empty array [].
+   */
+  readonly downloadOriginWhitelist?: string[];
 
   /**
    * Defines a list of domain origins that can access camera.
    */
-
   readonly cameraPermissionOriginWhitelist?: string[];
 
   /**


### PR DESCRIPTION
This adds origin-based validation to download requests, ensuring only requests from explicitly allowed origins and approved file types are processed. Enhances security by preventing unauthorised download triggers.

Closes #42

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209914524730226