### PR TITLE
chore: update android-ci packages

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set up Node.js
         uses: actions/setup-node@v2.5.1
         with:
@@ -19,7 +19,7 @@ jobs:
           distribution: temurin
           java-version: 11
       - name: Cache /node_modules
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}


### PR DESCRIPTION
Fix android CI failing here: https://github.com/ExodusMovement/react-native-webview/pull/40