### PR TITLE
feat: give granular control over page load for non HTTP URLs

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -20,7 +20,7 @@ const defaultDeeplinkWhitelist = ['https:'] as const;
 const defaultDeeplinkBlocklist = [`http:`, `file:`, `javascript:`] as const;
 
 const stringWhitelistToRegex = (originWhitelist: string): RegExp =>
-  new RegExp(`^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`)
+  new RegExp(`^${escapeStringRegexp(originWhitelist).replace(/\\\*/g, '.*')}$`);
 
 const matchWithRegexList = (
   compiledRegexList: readonly RegExp[],


### PR DESCRIPTION
## Summary

<img width="324" alt="Screenshot 2025-07-04 at 23 40 19" src="https://github.com/user-attachments/assets/51cfff69-481f-436b-8c26-ebf7d35cf995" />


Towards https://github.com/ExodusMovement/exodus-mobile/pull/29519

Currently we are getting `Webpage not available` error while opening `mailto:` URLs from the WebView on Android. ~This PR gives granular control over page load by exposing `onShouldStartLoadWithRequest` first. Thus we can decide on the client whether we want to load the page.~

I changed my mind and decided to keep the `onShouldStartLoadWithRequest` current behavior and match `mailto` from `originWhitelist` here as we do for http and https

A simplified diff in the mobile: 

```diff
diff --git a/src/screens/Web3/Browser.js b/src/screens/Web3/Browser.js
index 8fc3d744dc..68f7564870 100644
--- a/src/screens/Web3/Browser.js
+++ b/src/screens/Web3/Browser.js
@@ -593,6 +593,15 @@ const Web3Browser = ({ navigation, route }) => {
                   onLoadStart={handleLoadStart}
                   onLoadEnd={handleLoad}
                   onScroll={onScroll}
+                  originWhitelist={['https://*', 'mailto:*']}
+                  onShouldStartLoadWithRequest={(event) => {
+                    if (event.url.startsWith('mailto:')) {
+                      openLink(event.url)
+                      return false // Prevent WebView from loading the mailto link
+                    }
+
+                    return true
+                  }}
                   ref={webview}
                   deeplinkWhitelist={[
                     'https:',
``` 



