### PR TITLE
fix: mailto cannot be opened

### DIFF
--- a/src/WebViewShared.tsx
+++ b/src/WebViewShared.tsx
@@ -99,7 +99,7 @@ const createOnShouldStartLoadWithRequest = (
     
           if (foundMatchInAllowlist) {
             Linking.canOpenURL(url).then((supported) => {
-              if (supported && isTopFrame) {
+              if ((supported && isTopFrame) || protocol.startsWith('mailto:')) {
                 return Linking.openURL(url);
               }
               console.warn(`Can't open url: ${url}`);


### PR DESCRIPTION
## Summary

React linking canOpenURL does not recognize `mailto` protocol but it can open the mailto url. I agreed with @633kh4ck that it is less hacky approach then the [one](https://github.com/ExodusMovement/react-native-webview/pull/44) I commited previously. Plus it is less code on the client side.

Towards https://github.com/ExodusMovement/exodus-mobile/pull/29519

## Test plan

```
- [ ] Sync it to mobile
- [ ] Apply the following diff 
- [ ] Open spend card feature
- [ ] Open profile
- [ ] Click support link 
- [ ] Assert that the email app is opened
- [ ] Go back to the Exodus app
- [ ] Assert no error
```

```diff
--- a/src/screens/Web3/Browser.js
+++ b/src/screens/Web3/Browser.js
@@ -608,16 +608,23 @@ const Web3Browser = ({ navigation, route }) => {
                       injectedJavaScriptBeforeContentLoadedForMainFrameOnly
                       injectedJavaScriptForMainFrameOnly
                       source={{ uri: dappUrl }}
                       onError={handleError}
                       onLoadStart={handleLoadStart}
                       onLoadEnd={handleLoad}
                       onScroll={onScroll}
                       ref={webview}
+                      deeplinkWhitelist={[
+                        'https:',
+                        'bitcoin:',
+                        'ethereum:',
+                        'exodus:',
+                        'wc:',
+                        'mailto:',
+                      ]}
                       minimumChromeVersion={android}
                       minimumIOSVersion={ios}
                       validateMeta={handleValidateMeta}
                       validateData={handleValidateData}
                       unsupportedVersionComponent={handleUnsupportedVersion}
```

https://github.com/user-attachments/assets/f01c436d-c938-4ad1-9a44-8f4ee0650a89


