### PR TITLE
fix: compare strings, not object references

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -1079,7 +1079,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
       final int port = originUri.getPort();
       String origin = scheme + "://" + originUri.getHost();
 
-      if (port > 0 && ((scheme == "http" && port != 80) || (scheme == "https" && port != 443))) {
+      if (port > 0 && (("http".equals(scheme) && port != 80) || ("https".equals(scheme) && port != 443))) {
         origin += ":" + port;
       }
 


### PR DESCRIPTION
For `port` condition check, this is always going to fail for `scheme == "http"` because `==` in java compares object references, not values, so the origin is always going to remain without the port.