### PR TITLE
feat: support `shouldStartLoadTimeout` parameter (iOS)

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -71,6 +71,7 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *_Nonnull)request
 @property (nonatomic, copy) NSDictionary * _Nullable basicAuthCredential;
 @property (nonatomic, assign) BOOL pullToRefreshEnabled;
 @property (nonatomic, assign) BOOL enableApplePay;
+@property (nonatomic, assign) NSInteger shouldStartLoadTimeout;
 @property (nonatomic, copy) NSArray<NSDictionary *> * _Nullable menuItems;
 @property (nonatomic, copy) RCTDirectEventBlock onCustomMenuSelection;
 #if !TARGET_OS_OSX

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -113,6 +113,8 @@ RCT_EXPORT_VIEW_PROPERTY(enableApplePay, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(menuItems, NSArray);
 RCT_EXPORT_VIEW_PROPERTY(onCustomMenuSelection, RCTDirectEventBlock)
 
+RCT_EXPORT_VIEW_PROPERTY(shouldStartLoadTimeout, NSInteger)
+
 RCT_EXPORT_METHOD(postMessage:(nonnull NSNumber *)reactTag message:(NSString *)message)
 {
   [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *uiManager, NSDictionary<NSNumber *, RNCWebView *> *viewRegistry) {
@@ -254,8 +256,10 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
   request[@"lockIdentifier"] = @(_shouldStartLoadLock.condition);
   callback(request);
 
-  // Block the main thread for a maximum of 500ms until the JS thread returns
-  if ([_shouldStartLoadLock lockWhenCondition:0 beforeDate:[NSDate dateWithTimeIntervalSinceNow:.50]]) {
+  NSInteger timeoutMs = webView.shouldStartLoadTimeout;
+  NSTimeInterval timeoutSeconds = timeoutMs / 1000.0;
+
+  if ([_shouldStartLoadLock lockWhenCondition:0 beforeDate:[NSDate dateWithTimeIntervalSinceNow:timeoutSeconds]]) {
     BOOL returnValue = _shouldStartLoad;
     [_shouldStartLoadLock unlock];
     _shouldStartLoadLock = nil;

--- a/src/WebView.ios.tsx
+++ b/src/WebView.ios.tsx
@@ -74,7 +74,8 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
     cacheEnabled = true,
     originWhitelist = defaultOriginWhitelist,
     deeplinkWhitelist = defaultDeeplinkWhitelist,
-    textInteractionEnabled= true,
+    textInteractionEnabled = true,
+    shouldStartLoadTimeout = 500,
     injectedJavaScript,
     injectedJavaScriptBeforeContentLoaded,
     startInLoadingState,
@@ -208,6 +209,7 @@ const WebViewComponent = forwardRef<{}, IOSWebViewProps>((props, ref) => {
       mediaPlaybackRequiresUserAction={mediaPlaybackRequiresUserAction}
       ref={webViewRef}
       sharedCookiesEnabled={sharedCookiesEnabled}
+      shouldStartLoadTimeout={shouldStartLoadTimeout}
       // TODO: find a better way to type this.
       source={source}
       style={webViewStyles}

--- a/src/WebViewTypes.ts
+++ b/src/WebViewTypes.ts
@@ -321,6 +321,7 @@ export interface IOSNativeWebViewProps extends CommonNativeWebViewProps {
   enableApplePay?: boolean;
   textInteractionEnabled?: boolean;
   mediaCapturePermissionGrantType?: MediaCapturePermissionGrantType;
+  shouldStartLoadTimeout?: number;
 }
 
 export interface IOSWebViewProps extends WebViewSharedProps {
@@ -573,6 +574,15 @@ export interface IOSWebViewProps extends WebViewSharedProps {
    * @platform ios
    */
   onCustomMenuSelection?: (event: WebViewEvent) => void;
+
+  /**
+   * Timeout in milliseconds for the shouldStartLoad callback to respond.
+   * If the JS thread is busy and cannot respond within this time, navigation
+   * will be blocked.
+   * The default value is `500`.
+   * @platform ios
+   */
+  shouldStartLoadTimeout?: number;
 }
 
 export interface AndroidWebViewProps extends WebViewSharedProps {


### PR DESCRIPTION
Continues https://github.com/ExodusMovement/react-native-webview/pull/47 and allows consumers to configure the timeout value. Even `500ms` sometimes is not enough, the _first_ load for a relatively heavy-component with multiple renders might be up to 800ms in Dev based on my testing

My use-case is a hidden WebView, I'd like to be able to choose an arbitrary huge value because freezing the UI won't be an issue 

## Testing

Can be tested with this patch:
```
diff --git a/apple/RNCWebViewManager.m b/apple/RNCWebViewManager.m
index 54e2035..789af70 100644
--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -254,18 +254,23 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
   _shouldStartLoadLock = [[NSConditionLock alloc] initWithCondition:arc4random()];
   _shouldStartLoad = YES;
   request[@"lockIdentifier"] = @(_shouldStartLoadLock.condition);
+  NSDate *startTime = [NSDate date];
   callback(request);
 
   NSInteger timeoutMs = webView.shouldStartLoadTimeout;
+  RCTLogWarn(@"shouldStartLoad using timeout: %ldms", (long)timeoutMs);
   NSTimeInterval timeoutSeconds = timeoutMs / 1000.0;
 
   if ([_shouldStartLoadLock lockWhenCondition:0 beforeDate:[NSDate dateWithTimeIntervalSinceNow:timeoutSeconds]]) {
+    NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:startTime] * 1000;
+    RCTLogWarn(@"shouldStartLoad JS response took %.2fms", duration);
     BOOL returnValue = _shouldStartLoad;
     [_shouldStartLoadLock unlock];
     _shouldStartLoadLock = nil;
     return returnValue;
   } else {
-    RCTLogWarn(@"Did not receive response to shouldStartLoad in time, defaulting to NO");
+    NSTimeInterval duration = [[NSDate date] timeIntervalSinceDate:startTime] * 1000;
+    RCTLogWarn(@"Did not receive response to shouldStartLoad in time (%.2fms), defaulting to NO", duration);
     return NO;
   }
 }

```

- [ ] The "using timeout" log should print 500ms when no parameter is passed (the default value)
- [ ] The "using timeout" log should print the number you pass
- [ ] You should see the "Did not receive response to shouldStartLoad in time" log when the parameter is too low