### PR TITLE
feat: support async onShouldStartLoad requests

### DIFF
--- a/apple/RNCWebView.h
+++ b/apple/RNCWebView.h
@@ -19,14 +19,6 @@ typedef enum RNCWebViewPermissionGrantType : NSUInteger {
 
 @class RNCWebView;
 
-@protocol RNCWebViewDelegate <NSObject>
-
-- (BOOL)webView:(RNCWebView *_Nonnull)webView
-shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *_Nonnull)request
-   withCallback:(RCTDirectEventBlock _Nonnull)callback;
-
-@end
-
 @interface RNCWeakScriptMessageDelegate : NSObject<WKScriptMessageHandler>
 
 @property (nonatomic, weak, nullable) id<WKScriptMessageHandler> scriptDelegate;
@@ -37,7 +29,6 @@ shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *_Nonnull)request
 
 @interface RNCWebView : RCTView
 
-@property (nonatomic, weak) id<RNCWebViewDelegate> _Nullable delegate;
 @property (nonatomic, copy) NSDictionary * _Nullable source;
 @property (nonatomic, assign) BOOL messagingEnabled;
 @property (nonatomic, copy) NSString * _Nullable injectedJavaScript;

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -1106,6 +1106,21 @@ RCTAutoInsetsProtocol>
   NSURLRequest *request = navigationAction.request;
   BOOL isTopFrame = [request.URL isEqual:request.mainDocumentURL];
   
+  void (^allowNavigation)(void) = ^{
+    if (self->_onLoadingStart) {
+      // We have this check to filter out iframe requests and whatnot
+      if (isTopFrame) {
+        NSMutableDictionary<NSString *, id> *event = [self baseEvent];
+        [event addEntriesFromDictionary: @{
+            @"url": (request.URL).absoluteString,
+            @"navigationType": navigationTypes[@(navigationType)]
+          }];
+          self->_onLoadingStart(event);
+      }
+    }
+    decisionHandler(WKNavigationActionPolicyAllow);
+  };
+
   if (_onShouldStartLoadWithRequest) {
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     if (request.mainDocumentURL) {
@@ -1126,20 +1141,8 @@ RCTAutoInsetsProtocol>
     }
   }
   
-  if (_onLoadingStart) {
-    // We have this check to filter out iframe requests and whatnot
-    if (isTopFrame) {
-      NSMutableDictionary<NSString *, id> *event = [self baseEvent];
-      [event addEntriesFromDictionary: @{
-        @"url": (request.URL).absoluteString,
-        @"navigationType": navigationTypes[@(navigationType)]
-      }];
-      _onLoadingStart(event);
-    }
-  }
-  
   // Allow all navigation by default
-  decisionHandler(WKNavigationActionPolicyAllow);
+  allowNavigation();
 }
 
 /**

--- a/apple/RNCWebView.m
+++ b/apple/RNCWebView.m
@@ -9,6 +9,7 @@
 #import <React/RCTConvert.h>
 #import <React/RCTAutoInsetsProtocol.h>
 #import "RNCWKProcessPoolManager.h"
+#import "RNCWebViewDecisionManager.h"
 #if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
 #else
@@ -1122,6 +1123,16 @@ RCTAutoInsetsProtocol>
   };
 
   if (_onShouldStartLoadWithRequest) {
+    int lockIdentifier = [[RNCWebViewDecisionManager getInstance] setDecisionHandler:^(BOOL shouldStart) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        if (!shouldStart) {
+          decisionHandler(WKNavigationActionPolicyCancel);
+          return;
+        }
+        allowNavigation();
+      });
+    }];
+
     NSMutableDictionary<NSString *, id> *event = [self baseEvent];
     if (request.mainDocumentURL) {
       [event addEntriesFromDictionary: @{
@@ -1131,14 +1142,11 @@ RCTAutoInsetsProtocol>
     [event addEntriesFromDictionary: @{
       @"url": (request.URL).absoluteString,
       @"navigationType": navigationTypes[@(navigationType)],
-      @"isTopFrame": @(isTopFrame)
+      @"isTopFrame": @(isTopFrame),
+      @"lockIdentifier": @(lockIdentifier)
     }];
-    if (![self.delegate webView:self
-      shouldStartLoadForRequest:event
-                   withCallback:_onShouldStartLoadWithRequest]) {
-      decisionHandler(WKNavigationActionPolicyCancel);
-      return;
-    }
+    _onShouldStartLoadWithRequest(event);
+    return;
   }
   
   // Allow all navigation by default

--- a/apple/RNCWebViewDecisionManager.h
+++ b/apple/RNCWebViewDecisionManager.h
@@ -1,0 +1,18 @@
+#import <Foundation/Foundation.h>
+
+typedef void (^DecisionBlock)(BOOL);
+
+@interface RNCWebViewDecisionManager : NSObject {
+    int nextLockIdentifier;
+    NSMutableDictionary *decisionHandlers;
+}
+
+@property (nonatomic) int nextLockIdentifier;
+@property (nonatomic, retain) NSMutableDictionary *decisionHandlers;
+
++ (id)      getInstance;
+
+- (int)setDecisionHandler:(DecisionBlock)handler;
+- (void)    setResult:(BOOL)shouldStart
+    forLockIdentifier:(int)lockIdentifier;
+@end

--- a/apple/RNCWebViewDecisionManager.m
+++ b/apple/RNCWebViewDecisionManager.m
@@ -1,0 +1,48 @@
+#import "RNCWebViewDecisionManager.h"
+#import <React/RCTLog.h>
+
+
+
+@implementation RNCWebViewDecisionManager
+
+@synthesize nextLockIdentifier;
+@synthesize decisionHandlers;
+
++ (id)getInstance {
+    static RNCWebViewDecisionManager *lockManager = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        lockManager = [[self alloc] init];
+    });
+    return lockManager;
+}
+
+- (int)setDecisionHandler:(DecisionBlock)decisionHandler {
+    int lockIdentifier = self.nextLockIdentifier++;
+
+    [self.decisionHandlers setObject:decisionHandler forKey:@(lockIdentifier)];
+    return lockIdentifier;
+}
+
+- (void) setResult:(BOOL)shouldStart
+ forLockIdentifier:(int)lockIdentifier {
+    DecisionBlock handler = [self.decisionHandlers objectForKey:@(lockIdentifier)];
+    if (handler == nil) {
+        RCTLogWarn(@"Lock not found");
+        return;
+    }
+    handler(shouldStart);
+    [self.decisionHandlers removeObjectForKey:@(lockIdentifier)];
+}
+
+- (id)init {
+  if (self = [super init]) {
+      self.nextLockIdentifier = 1;
+      self.decisionHandlers = [[NSMutableDictionary alloc] init];
+  }
+  return self;
+}
+
+- (void)dealloc {}
+
+@end

--- a/apple/RNCWebViewDecisionManager.m
+++ b/apple/RNCWebViewDecisionManager.m
@@ -1,8 +1,16 @@
 #import "RNCWebViewDecisionManager.h"
 #import <React/RCTLog.h>
 
-
-
+/**
+ * Thread-safe singleton that manages navigation decision handlers for WKWebView.
+ *
+ * This class bridges async navigation decisions between:
+ * - WKWebView delegate (main thread) - stores decision handlers
+ * - React Native bridge (background thread) - resolves decisions from JS
+ *
+ * All public methods use @synchronized for thread safety since they access
+ * shared state (nextLockIdentifier and decisionHandlers) from different threads.
+ */
 @implementation RNCWebViewDecisionManager
 
 @synthesize nextLockIdentifier;
@@ -17,22 +25,39 @@
     return lockManager;
 }
 
+/**
+ * Stores a decision handler and returns a unique identifier.
+ * Called from the main thread (WKNavigationDelegate).
+ * @synchronized ensures atomic increment + insertion.
+ */
 - (int)setDecisionHandler:(DecisionBlock)decisionHandler {
-    int lockIdentifier = self.nextLockIdentifier++;
-
-    [self.decisionHandlers setObject:decisionHandler forKey:@(lockIdentifier)];
-    return lockIdentifier;
+    @synchronized (self) {
+        int lockIdentifier = self.nextLockIdentifier++;
+        [self.decisionHandlers setObject:decisionHandler forKey:@(lockIdentifier)];
+        return lockIdentifier;
+    }
 }
 
+/**
+ * Resolves a pending navigation decision.
+ * Called from the RN bridge thread (background) when JS responds.
+ *
+ * The handler is invoked OUTSIDE the @synchronized block to prevent deadlocks,
+ * since the handler dispatches to the main queue and could potentially
+ * trigger another navigation that re-enters this class.
+ */
 - (void) setResult:(BOOL)shouldStart
  forLockIdentifier:(int)lockIdentifier {
-    DecisionBlock handler = [self.decisionHandlers objectForKey:@(lockIdentifier)];
-    if (handler == nil) {
-        RCTLogWarn(@"Lock not found");
-        return;
+    DecisionBlock handler;
+    @synchronized (self) {
+        handler = [self.decisionHandlers objectForKey:@(lockIdentifier)];
+        if (handler == nil) {
+            RCTLogWarn(@"Lock not found");
+            return;
+        }
+        [self.decisionHandlers removeObjectForKey:@(lockIdentifier)];
     }
     handler(shouldStart);
-    [self.decisionHandlers removeObjectForKey:@(lockIdentifier)];
 }
 
 - (id)init {

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -10,8 +10,9 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTDefines.h>
 #import "RNCWebView.h"
+#import "RNCWebViewDecisionManager.h"
 
-@interface RNCWebViewManager () <RNCWebViewDelegate>
+@interface RNCWebViewManager ()
 @end
 
 @implementation RCTConvert (WKWebView)
@@ -35,10 +36,6 @@ RCT_ENUM_CONVERTER(RNCWebViewPermissionGrantType, (@{
 @end
 
 @implementation RNCWebViewManager
-{
-  NSConditionLock *_shouldStartLoadLock;
-  BOOL _shouldStartLoad;
-}
 
 RCT_EXPORT_MODULE()
 
@@ -49,7 +46,6 @@ RCT_EXPORT_MODULE()
 #endif // !TARGET_OS_OSX
 {
   RNCWebView *webView = [RNCWebView new];
-  webView.delegate = self;
   return webView;
 }
 
@@ -243,38 +239,11 @@ RCT_EXPORT_METHOD(requestFocus:(nonnull NSNumber *)reactTag)
   }];
 }
 
-#pragma mark - Exported synchronous methods
-
-- (BOOL)          webView:(RNCWebView *)webView
-shouldStartLoadForRequest:(NSMutableDictionary<NSString *, id> *)request
-             withCallback:(RCTDirectEventBlock)callback
-{
-  _shouldStartLoadLock = [[NSConditionLock alloc] initWithCondition:arc4random()];
-  _shouldStartLoad = YES;
-  request[@"lockIdentifier"] = @(_shouldStartLoadLock.condition);
-  callback(request);
-
-  // Block the main thread for a maximum of 500ms until the JS thread returns
-  if ([_shouldStartLoadLock lockWhenCondition:0 beforeDate:[NSDate dateWithTimeIntervalSinceNow:.50]]) {
-    BOOL returnValue = _shouldStartLoad;
-    [_shouldStartLoadLock unlock];
-    _shouldStartLoadLock = nil;
-    return returnValue;
-  } else {
-    RCTLogWarn(@"Did not receive response to shouldStartLoad in time, defaulting to NO");
-    return NO;
-  }
-}
+#pragma mark - Exported methods
 
 RCT_EXPORT_METHOD(startLoadWithResult:(BOOL)result lockIdentifier:(NSInteger)lockIdentifier)
 {
-  if ([_shouldStartLoadLock tryLockWhenCondition:lockIdentifier]) {
-    _shouldStartLoad = result;
-    [_shouldStartLoadLock unlockWithCondition:0];
-  } else {
-    RCTLogWarn(@"startLoadWithResult invoked with invalid lockIdentifier: "
-               "got %lld, expected %lld", (long long)lockIdentifier, (long long)_shouldStartLoadLock.condition);
-  }
+  [[RNCWebViewDecisionManager getInstance] setResult:result forLockIdentifier:(int)lockIdentifier];
 }
 
 @end

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -239,8 +239,6 @@ RCT_EXPORT_METHOD(requestFocus:(nonnull NSNumber *)reactTag)
   }];
 }
 
-#pragma mark - Exported methods
-
 RCT_EXPORT_METHOD(startLoadWithResult:(BOOL)result lockIdentifier:(NSInteger)lockIdentifier)
 {
   [[RNCWebViewDecisionManager getInstance] setResult:result forLockIdentifier:(int)lockIdentifier];

--- a/apple/RNCWebViewManager.m
+++ b/apple/RNCWebViewManager.m
@@ -239,9 +239,9 @@ RCT_EXPORT_METHOD(requestFocus:(nonnull NSNumber *)reactTag)
   }];
 }
 
-RCT_EXPORT_METHOD(startLoadWithResult:(BOOL)result lockIdentifier:(NSInteger)lockIdentifier)
+RCT_EXPORT_METHOD(startLoadWithResult:(BOOL)result lockIdentifier:(int)lockIdentifier)
 {
-  [[RNCWebViewDecisionManager getInstance] setResult:result forLockIdentifier:(int)lockIdentifier];
+  [[RNCWebViewDecisionManager getInstance] setResult:result forLockIdentifier:lockIdentifier];
 }
 
 @end


### PR DESCRIPTION
The existing approach with locking the main thread to make a synchronous call asking JS "can I proceed with this URL" isn't reliable. Even the recent timeout bump to 500ms https://github.com/ExodusMovement/react-native-webview/pull/47 didn't help, we still experience the loading issues. Bumping the timeout even more (for example with https://github.com/ExodusMovement/react-native-webview/pull/48) would inevitably lead to performance degradation because of the locked thread. We should come up with a more reliable solution

### The bottleneck

I've put some logs to diagnose what exactly is the bottleneck. The [JS callback](https://github.com/ExodusMovement/react-native-webview/blob/1d62365e97331944cc54edd1ee4cf926b5152aca/src/WebViewShared.tsx#L84-L124) works super fast, but the problem is that sometimes it seems to be called **after** Native already makes the decision after the 500ms default timeout:

```
 Timeline:
  0ms      Native dispatches event
           |
           |  (JS thread busy)
           |
  501ms    Native TIMEOUT → blocks navigation
           |
 >501ms   JS receives event, responds "allow"
           |
           ✗ Response ignored - decision already made 
```


### The solution

Let's mirror the async architecture of the `onShouldStartLoad` calls from https://github.com/react-native-webview/react-native-webview. We can easily backport most of the code.

I recommend reviewing commit by commit

Notes:
- the [first commit](https://github.com/ExodusMovement/react-native-webview/commit/1e6070c9c752175367a708adfba09ef4a4d69ab0) cherry-picks `WebViewDecisionManager` from  upstream with minor formatting changes
- the other commits rely on the upstream code as well, but with a few minor changes to conform to our codebase. I’m going to leave the code references below.

### Testing

- [ ] WebView loads content normally when JS responds with `true`
- [ ] WebView rejects loading when JS responds with `false`